### PR TITLE
feature/CXIP-324 & feature/CXIP-326: add network and timestamp to logs from operator

### DIFF
--- a/src/commands/operator/index.ts
+++ b/src/commands/operator/index.ts
@@ -513,7 +513,7 @@ export default class Operator extends Command {
     }
   }
 
-  structuredLog(network: string, msg: string) {
+  structuredLog(network: string, msg: string): void {
     const timestamp = new Date(Date.now()).toISOString()
     const timestampColor = color.keyword('green')
 


### PR DESCRIPTION
## Describe Changes

I made this more better by doing ...

- Add new `structuredLog` method to log operator command with network and timestamp
- Updated operator logs to use new method. 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
