### PR TITLE
CXIP-365: Websocket re-connect logic

### DIFF
--- a/src/commands/operator/index.ts
+++ b/src/commands/operator/index.ts
@@ -121,15 +121,29 @@ export default class Operator extends Command {
     fs.writeFileSync(filePath, JSON.stringify(lastBlocks), 'utf8')
   }
 
-  failoverWebSocketProvider(network: string, rpcEndpoint: string): ethers.providers.WebSocketProvider {
+  disconnectBuilder(userWallet: ethers.Wallet, network: string, rpcEndpoint: string, subscribe: boolean): (err: any) => void {
+    return (err: any) => {
+      (this.providers[network] as ethers.providers.WebSocketProvider).destroy().then(() => {
+        this.debug('onDisconnect')
+        this.log(network, 'WS connection was closed', JSON.stringify(err, null, 2))
+        this.providers[network] = this.failoverWebSocketProvider(userWallet, network, rpcEndpoint, subscribe)
+        this.wallets[network] = userWallet.connect(this.providers[network] as ethers.providers.WebSocketProvider)
+      })
+    }
+  }
+
+  failoverWebSocketProvider(userWallet: ethers.Wallet, network: string, rpcEndpoint: string, subscribe: boolean): ethers.providers.WebSocketProvider {
+    this.debug('this.providers', network)
     const provider = new ethers.providers.WebSocketProvider(rpcEndpoint)
     keepAlive({
       provider,
-      onDisconnect: err => {
-        this.providers[network] = this.failoverWebSocketProvider.bind(this)(network, rpcEndpoint)
-        this.structuredLog(network, `The ws connection was closed ${JSON.stringify(err, null, 2)}`)
-      },
+      onDisconnect: this.disconnectBuilder.bind(this)(userWallet, network, rpcEndpoint, true),
     })
+    this.providers[network] = provider
+    if (subscribe) {
+      this.networkSubscribe(network)
+    }
+
     return provider
   }
 
@@ -137,6 +151,7 @@ export default class Operator extends Command {
     loadNetworks: string[],
     configFile: ConfigFile,
     userWallet: ethers.Wallet | undefined,
+    subscribe: boolean,
   ): Promise<void> {
     for (let i = 0, l = loadNetworks.length; i < l; i++) {
       const network = loadNetworks[i]
@@ -148,7 +163,7 @@ export default class Operator extends Command {
 
           break
         case 'wss:':
-          this.providers[network] = this.failoverWebSocketProvider.bind(this)(network, rpcEndpoint)
+          this.providers[network] = this.failoverWebSocketProvider(userWallet!, network, rpcEndpoint, subscribe)
           break
         default:
           throw new Error('Unsupported RPC provider protocol -> ' + protocol)
@@ -285,7 +300,7 @@ export default class Operator extends Command {
     }
 
     CliUx.ux.action.start(`Starting operator in mode: ${OperatorMode[this.operatorMode]}`)
-    await this.initializeEthers(flags.networks, configFile, userWallet)
+    await this.initializeEthers(flags.networks, configFile, userWallet, false)
 
     this.bridgeAddress = (await this.holograph.getBridge()).toLowerCase()
     this.factoryAddress = (await this.holograph.getFactory()).toLowerCase()


### PR DESCRIPTION
## Describe Changes

Adding the code needed for proper websocket disconnect recovery

- Adding `disconnectBuilder` function to dynamically build failover logic
- Modified `failoverWebSocketProvider` function to use the `disconnectBuilder` for recovery

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
