### PR TITLE
Add checks for txs before indexing into array

### DIFF
--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -206,6 +206,7 @@ export default class Indexer extends Command {
         if (
           res &&
           res.data &&
+          res.data.transactions !== undefined &&
           res.data.transactions[0] !== undefined &&
           this.networkMonitor.latestBlockHeight > res.data.transaction[0]
         ) {
@@ -354,6 +355,7 @@ export default class Indexer extends Command {
       if (
         res &&
         res.data &&
+        res.data.transactions !== undefined &&
         res.data.transactions[0] !== undefined &&
         this.networkMonitor.latestBlockHeight > res.data.transaction[0]
       ) {
@@ -448,6 +450,7 @@ export default class Indexer extends Command {
       if (
         res &&
         res.data &&
+        res.data.transactions !== undefined &&
         res.data.transactions[0] !== undefined &&
         this.networkMonitor.latestBlockHeight > res.data.transaction[0]
       ) {


### PR DESCRIPTION
## Describe Changes

- Handles this error: 

```
[2022-08-11T20:35:42.112Z] [Indexer] [Fuji] -> Successfully found collection at 0x5229bbab7014f39e2cd9bf9dad03ee7f340456b1
  holo:indexer exitRouter triggered +1ms
  holo:indexer
  holo:indexer Error: TypeError: Cannot read properties of undefined (reading '0') +0ms
  ```

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
