### PR TITLE
Feature/HOLO-406-Add network status to health check server

### DIFF
--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -98,7 +98,7 @@ export default class Indexer extends Command {
 
     // Start server
     if (enableHealthCheckServer) {
-      startHealthcheckServer()
+      startHealthcheckServer({networkMonitor: this.networkMonitor})
     }
   }
 

--- a/src/commands/operator/index.ts
+++ b/src/commands/operator/index.ts
@@ -111,7 +111,7 @@ export default class Operator extends Command {
 
     // Start server
     if (enableHealthCheckServer) {
-      startHealthcheckServer()
+      startHealthcheckServer({networkMonitor: this.networkMonitor})
     }
   }
 

--- a/src/commands/propagator/index.ts
+++ b/src/commands/propagator/index.ts
@@ -115,7 +115,7 @@ export default class Propagator extends Command {
 
     // Start server
     if (enableHealthCheckServer) {
-      startHealthcheckServer()
+      startHealthcheckServer({networkMonitor: this.networkMonitor})
     }
   }
 

--- a/src/utils/health-check-server.ts
+++ b/src/utils/health-check-server.ts
@@ -1,23 +1,25 @@
 import {IncomingMessage, ServerResponse} from 'node:http'
 import http from 'node:http'
 
-const requestListener = function (req: IncomingMessage, res: ServerResponse) {
-  res.setHeader('Content-Type', 'application/json')
-  if (req.url === '/healthcheck') {
-    res.writeHead(200)
-    res.end(JSON.stringify({status: 'alive'}))
-  } else {
-    res.writeHead(200)
-    res.end(JSON.stringify({hello: 'evil person'}))
-  }
-}
 
-export function startHealthcheckServer(): void {
+export function startHealthcheckServer({ networkMonitor }: any): any {
   const host = '0.0.0.0'
   const port = 6000
-  const server = http.createServer(requestListener)
 
-  server.listen(6000, host, () => {
+  const server = http.createServer(function (req: IncomingMessage, res: ServerResponse) {
+    res.setHeader('Content-Type', 'application/json')
+    if (req.url === '/healthcheck') {
+      const providerStatus =  networkMonitor.getProviderStatus()
+      res.writeHead(200)
+      res.end(JSON.stringify({status: 'alive', providerStatus }))
+    } else {
+      res.writeHead(200)
+      res.end(JSON.stringify({hello: 'evil person'}))
+    }
+  })
+
+  server.listen(port, host, () => {
     console.log(`Server is running on http://${host}:${port}`)
   })
 }
+

--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -153,6 +153,27 @@ export class NetworkMonitor {
     '0xe8d23d927749ec8e512eb885679c2977d57068839d8cca1a85685dbbea0648f6': 'Packet',
   }
 
+  getProviderStatus() {
+    const outputNetworks = ['rinkeby', 'mumbai', 'fuji']
+    const output = {} as any
+
+    // eslint-disable-next-line guard-for-in
+    for (const n of outputNetworks) {
+      if(this.providers[n]) {
+        const current = this.providers[n] as ethers.providers.WebSocketProvider
+        if ( current._wsReady && current._websocket._socket.readyState === 'open'){
+          output[n] = 'CONNECTED'
+        }
+      } else {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        output[n] = this.configFile.networks[n].providerUrl ? 'DISCONNECTED' : 'NOT_CONFIGURED'
+      }
+    }
+
+    return output
+  }
+
   constructor(options: NetworkMonitorOptions) {
     this.parent = options.parent
     this.configFile = options.configFile
@@ -679,3 +700,4 @@ export class NetworkMonitor {
     return output
   }
 }
+


### PR DESCRIPTION
## Describe Changes

If the `--healthCheck` flag is provided to propagator, indexer, or operator the server will return an object with the connection status.

```
➜ curl localhost:6000/healthcheck
{"status":"alive","providerStatus":{"rinkeby":"DISCONNECTED","mumbai":"DISCONNECTED","fuji":"CONNECTED"}}%  
```

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
