### PR TITLE
Changes for the new trigger for the testnet branch

### DIFF
--- a/.github/workflows/cicd_staging.yaml
+++ b/.github/workflows/cicd_staging.yaml
@@ -23,7 +23,7 @@ env:
   #TODO - create new gh secret for prod. should be different from staging????
   STG_HOLO_INDEXER_OPERATOR_API_KEY: ${{ secrets.HOLO_INDEXER_OPERATOR_API_KEY }}
   #
-  STG_HOLO_INDEXER_HOST: http://dev-nest-api.develop.svc.cluster.local:443
+  STG_HOLO_INDEXER_HOST: http://api-test-holo-api.testnet.svc.cluster.local:443
   #
   # notice: all 3 have the same password
   STG_HOLO_INDEXER_PASSWORD   : ${{ secrets.STG_HOLO_INDEXER_PASSWORD }}
@@ -35,7 +35,7 @@ env:
   #
   ABI_ENVIRONMENT: testnet # same for all 3 [indexer,operator,propagator]
   #
-  STG_COMMON_NAMESPACE: holocli
+  STG_COMMON_NAMESPACE: holocli-test
   STG_DOMAIN: "cxipchain.xyz"
 
 # notice: the trigger
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Login to ECR
-        id: login-ecr
+        id  : login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build image
@@ -81,7 +81,7 @@ jobs:
           aws-secret-access-key: ${{ env.AWS_ACCESS_KEY }} #notice: unique for each env
           aws-region           : ${{ env.AWS_REGION }}
 
-      - name: Create holocli dev ns
+      - name: Create holocli ns
         uses: tensor-hq/eksctl-helm-action@main
         with:
           eks_cluster: ${{ env.CLUSTER_NAME }}
@@ -98,13 +98,13 @@ jobs:
           CHART_VERSION: ${{ env.STG_HOLO_INDEXER_HELM_CHART_VERSION }}
           #
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run : |
+        run: |
           helm pull oci://$ECR_REGISTRY/$CHART_REPO --version $CHART_VERSION
 
       - name: -> Deploy INDEXER cli in staging [namespace -> ${{ steps.STG_COMMON_NAMESPACE }}]
         uses: tensor-hq/eksctl-helm-action@main
         env:
-          RELEASE_NAME: indexer-dev #notice
+          RELEASE_NAME: indexer-test #notice
         with:
           eks_cluster: ${{ env.CLUSTER_NAME }}
           command: |-
@@ -137,13 +137,13 @@ jobs:
           CHART_VERSION: ${{ env.STG_HOLO_OPERATOR_HELM_CHART_VERSION }}
           #
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run : |
+        run: |
           helm pull oci://$ECR_REGISTRY/$CHART_REPO --version $CHART_VERSION
 
       - name: -> Deploy OPERATOR cli in staging [namespace -> ${{ env.STG_COMMON_NAMESPACE }}]
         uses: tensor-hq/eksctl-helm-action@main
         env:
-          RELEASE_NAME: operator-dev #notice
+          RELEASE_NAME: operator-test #notice
         with:
           eks_cluster: ${{ env.CLUSTER_NAME }}
           command: |-
@@ -174,13 +174,13 @@ jobs:
           CHART_VERSION: ${{ env.STG_HOLO_PROPAGATOR_HELM_CHART_VERSION }}
           #
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run : |
+        run: |
           helm pull oci://$ECR_REGISTRY/$CHART_REPO --version $CHART_VERSION
 
       - name: -> Deploy PROPAGATOR cli in staging [namespace -> ${{ env.STG_COMMON_NAMESPACE }}]
         uses: tensor-hq/eksctl-helm-action@main
         env:
-          RELEASE_NAME: propagator-dev #notice
+          RELEASE_NAME: propagator-test #notice
         with:
           eks_cluster: ${{ env.CLUSTER_NAME }}
           command: |-
@@ -204,10 +204,10 @@ jobs:
       - name: -> Info for the new deployments
         uses: tensor-hq/eksctl-helm-action@main
         env:
-          INDEXER_RELEASE_NAME   : indexer-dev
-          OPERATOR_RELEASE_NAME  : operator-dev
-          PROPAGATOR_RELEASE_NAME: propagator-dev
-          LB_URL: staging-alb-1490082055.us-west-2.elb.amazonaws.com
+          INDEXER_RELEASE_NAME   : indexer-test
+          OPERATOR_RELEASE_NAME  : operator-test
+          PROPAGATOR_RELEASE_NAME: propagator-test
+          LB_URL: "https://staging-alb-1490082055.us-west-2.elb.amazonaws.com"
         with:
           eks_cluster: ${{ env.CLUSTER_NAME }}
           command: |-
@@ -224,13 +224,13 @@ jobs:
 
             echo "------------------------ Healthchecks ------------------------"
             ENDPOINT=$INDEXER_RELEASE_NAME-health.${{ env.STG_DOMAIN }}
-            echo "curl -k -H \"Host: $ENDPOINT\" https://$LB_URL/healthcheck"
-            curl -k -H "Host: $ENDPOINT" https://$LB_URL/healthcheck | jq '.status'
+            echo "curl -k -H \"Host: $ENDPOINT\" $LB_URL/healthcheck"
+            curl -k -H "Host: $ENDPOINT" $LB_URL/healthcheck | jq '.status'
 
             ENDPOINT=$OPERATOR_RELEASE_NAME-health.${{ env.STG_DOMAIN }}
-            echo "curl -k -H \"Host: $ENDPOINT\" https://$LB_URL/healthcheck"
-            curl -k -H "Host: $ENDPOINT" https://$LB_URL/healthcheck | jq '.status'
+            echo "curl -k -H \"Host: $ENDPOINT\" $LB_URL/healthcheck"
+            curl -k -H "Host: $ENDPOINT" $LB_URL/healthcheck | jq '.status'
 
             ENDPOINT=$PROPAGATOR_RELEASE_NAME-health.${{ env.STG_DOMAIN }}
             echo "curl -k -H \"Host: $ENDPOINT\" https://$LB_URL/healthcheck"
-            curl -k -H "Host: $ENDPOINT" https://$LB_URL/healthcheck | jq '.status'
+            curl -k -H "Host: $ENDPOINT" $LB_URL/healthcheck | jq '.status'


### PR DESCRIPTION
## Describe Changes

- I updated the cicd trigger so it is fired up from testnet branch, not develop.
- So, testnet code will be deployed in the holocli namespace in staging
- Also, I updated the indexer/operator/propagator helm charts in order to add the new ABI_ENVIRONMENT env var 
- Note: the indexer host is still pointing to the api in the develop ns. Do we want to point it to the testnet ns [when it is live]? 


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
