### PR TITLE
Disable the prod deployment

### DIFF
--- a/.github/workflows/cicd_prod0.yaml
+++ b/.github/workflows/cicd_prod0.yaml
@@ -47,7 +47,7 @@ env:
 on:
   pull_request:
     branches:
-      - testnet
+      - this-is-on-purpose-wrong!!!! # <--- TODO
     types: [closed]
 
 jobs:


### PR DESCRIPTION
## Describe Changes

The trigger for the prod deployment was when a  PR is merged and closed in testnet.
i dont think that we want that.

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Code styles have been enforced
- [ ] I have checked eslint
