### PR TITLE
Updated the helm charts to remove Rinkeby references for the holoclis

### DIFF
--- a/.github/workflows/cicd_develop_staging.yaml
+++ b/.github/workflows/cicd_develop_staging.yaml
@@ -11,8 +11,8 @@ env:
   #
   DEV_IMAGE_TAG: dev-${{ github.sha }}
   #######################################
-  STG_HOLO_INDEXER_HELM_CHART_VERSION: 0.0.37
-  STG_HOLO_OPERATOR_HELM_CHART_VERSION: 0.0.30
+  STG_HOLO_INDEXER_HELM_CHART_VERSION: 0.0.39
+  STG_HOLO_OPERATOR_HELM_CHART_VERSION: 0.0.31
   #######################################
   CLUSTER_NAME: staging
   #
@@ -121,6 +121,7 @@ jobs:
           ENABLE_DEBUG: "true"
           HEALTHCHECK : "true"
           MODE        : "auto"
+          NETWORK     : "fuji mumbai goerli"
         with:
           eks_cluster: ${{ env.CLUSTER_NAME }}
           command: |-
@@ -138,7 +139,9 @@ jobs:
             --set ENABLE_DEBUG=$ENABLE_DEBUG \
             --set HEALTHCHECK=$HEALTHCHECK \
             --set MODE=$MODE \
-            --set NETWORK="fuji mumbai rinkeby goerli" \
+            --set NETWORK="${NETWORK}" \
+            --set dev_rpc_config_values.bridge_source="goerli" \
+            --set dev_rpc_config_values.bridge_destination="mumbai" \
             \
             --set dev_rpc_config_values.fuji_rpc_url=${{ env.indexer_dev_fuji_rpc_url }} \
             --set dev_rpc_config_values.mumbai_rpc_url=${{ env.indexer_dev_mumbai_rpc_url }} \
@@ -193,6 +196,8 @@ jobs:
             --set ENABLE_SYNC=$ENABLE_SYNC \
             --set HEALTHCHECK=$HEALTHCHECK \
             --set MODE=$MODE \
+            --set dev_rpc_config_values.bridge_source="goerli" \
+            --set dev_rpc_config_values.bridge_destination="mumbai" \
             \
             --set dev_rpc_config_values.fuji_rpc_url=${{ env.operator_dev_fuji_rpc_url }} \
             --set dev_rpc_config_values.mumbai_rpc_url=${{ env.operator_dev_mumbai_rpc_url }} \


### PR DESCRIPTION
## Describe Changes

- New helm chart versions [removed the Rinkeby refs for indexer/operator]
- Managed to set the NETWORK env var in cicd , as a value with spaces , and Helm to accept it without errors
- Added the `bridge_source` and `bridge_destination` vars int he cicd [maybe we want to manipulate them in the immediate future]
- Replaced `rinkeby` with `goerli` in the `bridge_source` value

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
