### PR TITLE
Add TooManyRestarts post-deployment cicd check

### DIFF
--- a/.github/workflows/cicd_develop_staging.yaml
+++ b/.github/workflows/cicd_develop_staging.yaml
@@ -242,3 +242,54 @@ jobs:
             ENDPOINT=$OPERATOR_RELEASE_NAME-health.${{ env.STG_DOMAIN }}
             echo "curl -k -H \"Host: $ENDPOINT\" $LB_URL/healthcheck"
             curl -k -H "Host: $ENDPOINT" $LB_URL/healthcheck | jq '.status'
+
+  datadog-log-checks:
+      #####
+      needs: [deploy-to-staging]
+      name: datadog-log-checks
+      runs-on: ubuntu-latest
+      #####
+      env:
+        DD_API_KEY: ${{ secrets.STAGING_DD_API_KEY }}
+        DD_APPLICATION_KEY: ${{ secrets.PYTHON_TESTS_DD_APPLICATION_KEY }}
+        #
+        CHECK_TIMEFRAME: 5 # in minutes
+        RUN_FOR: 5 # in minutes
+
+      steps:
+        - name: Sanitize the branch name to use with Helm
+          id: sanitized_branch
+          shell: bash
+          # replaces '/' to '-' , '_' to '-' , uppercase to lowercase
+          run: echo "##[set-output name=branch;]$( echo ${GITHUB_REF_NAME} | tr '/' '-' | tr '_' '-' | tr '[:upper:]' '[:lower:]' )"
+
+        - name: Checkout tests repo
+          uses: actions/checkout@v3
+          with:
+            repository: holographxyz/qa
+            ref  : main  # notice: main/wip
+            token: ${{ secrets.HOLOGRAPH_GITHUB_PERSONAL_ACCESS_TOKEN }}  # reminder -> created in my personal GH account
+            path : './'
+
+        - name: Setup python
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.8
+
+        - name: Install Python packages
+          run : |
+            python -m pip install datadog_api_client
+
+        - name: Check Datadog monitor for -> Too Many Pod Restarts [indexer]
+          env:
+            ENV: ${{ env.CLUSTER_NAME }}
+            RELEASE_NAME: "indexer-dev"
+          run: |
+            python python_api_tests/test_dd_k8s_holocli_TooManyRestarts.py
+
+        - name: Check Datadog monitor for -> Too Many Pod Restarts [operator]
+          env:
+            ENV: ${{ env.CLUSTER_NAME }}
+            RELEASE_NAME: "operator-dev"
+          run: |
+            python python_api_tests/test_dd_k8s_holocli_TooManyRestarts.py


### PR DESCRIPTION
## Describe Changes

- added the TooManyRestarts script to run after each deployment and check for 5 mins if the pod is restarting , which will means some kind of failure

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
