### PR TITLE
Hotfix: Removing `SIGKILL` event

### DIFF
--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -598,7 +598,7 @@ export class NetworkMonitor {
     }
 
     // Catch all exit events
-    for (const eventType of [`EEXIT`, `SIGINT`, `SIGUSR1`, `SIGUSR2`, `uncaughtException`, `SIGTERM`, `SIGKILL`]) {
+    for (const eventType of [`EEXIT`, `SIGINT`, `SIGUSR1`, `SIGUSR2`, `uncaughtException`, `SIGTERM`]) {
       process.on(eventType, this.exitRouter.bind(this, {exit: true}))
     }
 
@@ -818,7 +818,7 @@ export class NetworkMonitor {
     /**
      * Before exit, save the block heights to the local db
      */
-    if ((exitCode && exitCode === 0) || exitCode === 'SIGINT' || exitCode === 'SIGTERM' || exitCode === 'SIGKILL') {
+    if ((exitCode && exitCode === 0) || exitCode === 'SIGINT' || exitCode === 'SIGTERM') {
       if (this.exited === false) {
         this.log('')
         if (this.needToSubscribe) {


### PR DESCRIPTION
## Describe Changes

Apparently `SIGKILL` event cannot be listened to. So removing it from exit handler.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
