### PR TITLE
Feature/holo 617 add logic to get update nft by graphql

### DIFF
--- a/src/commands/analyze/index.ts
+++ b/src/commands/analyze/index.ts
@@ -86,7 +86,7 @@ export default class Analyze extends Command {
   static hidden = true
   static description = 'Extract all operator jobs and get their status'
   static examples = [
-    `$ <%= config.bin %> <%= command.id %> --scope='{"network":"goerli","startBlock":10857626,"endBlock":11138178}' --scope='{"network":"mumbai","startBlock":26758573,"endBlock":27457918}' --scope='{"network":"fuji","startBlock":11406945,"endBlock":12192217}'`,
+    `$ <%= config.bin %> <%= command.id %> --scope='{"network":"goerli","startBlock":10857626,"endBlock":11138178}' --scope='{"network":"mumbai","startBlock":26758573,"endBlock":27457918}' --scope='{"network":"fuji","startBlock":11406945,"endBlock":12192217}' --updateApiUrl='https://api.holograph.xyz'`,
   ]
 
   static flags = {
@@ -104,7 +104,7 @@ export default class Analyze extends Command {
       default: `./${getEnvironment()}.analyzeResults.json`,
       multiple: false,
     }),
-    mutateApi: Flags.string({
+    updateApiUrl: Flags.string({
       description: 'Update database cross-chain table with correct beam status',
     }),
   }
@@ -124,14 +124,14 @@ export default class Analyze extends Command {
    */
   async run(): Promise<void> {
     const {flags} = await this.parse(Analyze)
-    const mutateApi = flags.mutateApi as string
+    const updateApiUrl = flags.updateApiUrl
 
     this.log('Loading user configurations...')
     const {environment, configFile} = await ensureConfigFileIsValid(this.config.configDir, undefined, false)
     this.log('User configurations loaded.')
     this.environment = environment
 
-    if (mutateApi) {
+    if (updateApiUrl !== undefined) {
       try {
         const logger: Logger = {
           log: this.log,
@@ -140,7 +140,7 @@ export default class Analyze extends Command {
           error: this.error,
           jsonEnabled: () => false,
         }
-        this.apiService = new ApiService(mutateApi, logger)
+        this.apiService = new ApiService(updateApiUrl, logger)
         await this.apiService.operatorLogin()
       } catch (error: any) {
         this.error(error)

--- a/src/commands/analyze/index.ts
+++ b/src/commands/analyze/index.ts
@@ -104,8 +104,8 @@ export default class Analyze extends Command {
       default: `./${getEnvironment()}.analyzeResults.json`,
       multiple: false,
     }),
-    updateApiOn: Flags.string({
-      description: 'Update DB cross-chain table with correct beam status',
+    mutateApi: Flags.string({
+      description: 'Update database cross-chain table with correct beam status',
     }),
   }
 
@@ -124,14 +124,14 @@ export default class Analyze extends Command {
    */
   async run(): Promise<void> {
     const {flags} = await this.parse(Analyze)
-    const updateApiOn = flags.updateApiOn as string
+    const mutateApi = flags.mutateApi as string
 
     this.log('Loading user configurations...')
     const {environment, configFile} = await ensureConfigFileIsValid(this.config.configDir, undefined, false)
     this.log('User configurations loaded.')
     this.environment = environment
 
-    if (updateApiOn) {
+    if (mutateApi) {
       try {
         const logger: Logger = {
           log: this.log,
@@ -140,7 +140,7 @@ export default class Analyze extends Command {
           error: this.error,
           jsonEnabled: () => false,
         }
-        this.apiService = new ApiService(updateApiOn, logger)
+        this.apiService = new ApiService(mutateApi, logger)
         await this.apiService.operatorLogin()
       } catch (error: any) {
         this.error(error)
@@ -333,7 +333,7 @@ export default class Analyze extends Command {
    */
   async updateBeamStatusDB(beam: AvailableJob, rawData?: RawData): Promise<void> {
     if (this.apiService === undefined) {
-      return
+      throw new Error('API service is not defined')
     }
 
     let crossChainTx: CrossChainTransaction

--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -1065,11 +1065,11 @@ export default class Indexer extends HealthCheck {
     tokenId: string,
     tags: (string | number)[],
   ): Promise<void> {
-    const data = JSON.stringify({
-      chainId: transaction.chainId,
-      status: 'MINTED',
-      tx: transaction.hash,
-    })
+    // const data = JSON.stringify({
+    //   chainId: transaction.chainId,
+    //   status: 'MINTED',
+    //   tx: transaction.hash,
+    // })
     this.networkMonitor.structuredLog(
       network,
       `Successfully found NFT with tokenId ${tokenId} from ${contractAddress}`,
@@ -1081,7 +1081,7 @@ export default class Indexer extends HealthCheck {
       tags,
     )
 
-    // TODO: Replace patch request with graphql mutation
+    // // TODO: Replace patch request with graphql mutation
     // await this.sendPatchRequest(
     //   {
     //     responseData,

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -58,7 +58,7 @@ class ApiService {
       }
     `
     const data = await this.client.request<NftResponse>(query, {tx})
-    this.logger.debug('found: ', data.nft)
+    this.logger.debug('Found NFT: ', data.nft)
     return data.nft
   }
 
@@ -86,7 +86,7 @@ class ApiService {
       updateNftInput: updateNftInput,
     })
 
-    this.logger.debug('updated to:', data.nft)
+    this.logger.debug('Updated NFT', data.nft)
     return data.nft
   }
 
@@ -114,7 +114,7 @@ class ApiService {
       }
   `
     const data = await this.client.request<CrossChainTransactionResponse>(query, {jobHash})
-    this.logger.debug('found: ', data.crossChainTransaction)
+    this.logger.debug('Found cross chain transaction:', data.crossChainTransaction)
     return data.crossChainTransaction
   }
 
@@ -149,7 +149,7 @@ class ApiService {
       createOrUpdateCrossChainTransactionInput: updateCrossChainTransactionStatusInput,
     })
 
-    this.logger.debug('updated to:', data.createOrUpdateCrossChainTransaction)
+    this.logger.debug('Updated cross chain transaction:', data.createOrUpdateCrossChainTransaction)
     return data.createOrUpdateCrossChainTransaction
   }
 }

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -45,7 +45,7 @@ class ApiService {
     }
 
     this.client.setHeader('authorization', `Bearer ${JWT}`)
-    this.logger.log(`JWT = ${JWT}`)
+    this.logger.log(`Operator JWT: ${JWT}`)
   }
 
   async queryNftByTx(tx: string): Promise<Nft> {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -56,3 +56,48 @@ export interface CrossChainTransaction {
   sourceAddress?: string
   data?: string
 }
+
+export enum NftStatus {
+  'DRAFT' = 'DRAFT',
+  'SIGNED' = 'SIGNED',
+  'MINTING' = 'MINTING',
+  'MINTED' = 'MINTED',
+  'FAILED' = 'FAILED',
+  'BRIDGING' = 'BRIDGING',
+}
+
+export enum TokenType {
+  'ERC721' = 'ERC721',
+  'ERC1155' = 'ERC1155',
+}
+
+export type Nft = {
+  id: string
+  createdAt: Date
+  updatedAt: Date
+  userId: string
+  collectionId: string
+  name: string
+  description: string | null
+  creator: string | null
+  type: TokenType
+  ipfsImageCid: string | null
+  ipfsMetadataCid: string | null
+  awsUrl: string | null
+  arweaveUrl: string | null
+  fileExtension: string | null
+  chainId: number | null
+  status: NftStatus
+  isActive: boolean
+  contractAddress: string | null
+  owner: string | null
+  tx: string | null
+  isDeployed: boolean | null
+  tokenId: string | null
+}
+
+export interface NftResponse {
+  nft: Nft
+}
+
+export type UpdateNftInput = Omit<Nft, 'id'>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -94,8 +94,12 @@ export type Nft = {
   tokenId: string | null
 }
 
-export interface NftResponse {
-  nft: Nft
+export interface NftQueryResponse {
+  nftByTx: Nft
+}
+
+export interface NftMutationResponse {
+  updateNft: Nft
 }
 
 export type UpdateNftInput = Omit<Nft, 'id'>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -72,9 +72,7 @@ export enum TokenType {
 }
 
 export type Nft = {
-  id: string
-  createdAt: Date
-  updatedAt: Date
+  id?: string
   userId: string
   collectionId: string
   name: string


### PR DESCRIPTION
## Describe Changes
- Add new API types for Nft
- Add GraphQL calls for querying NFTs by transaction hash and updating via mutation
- Update chain data (chainId, status, hash) in API request
- Disable Nft mint jobs from going to the db job handler (need to update the rest of the calls to graphql for this to work)
- Minor cleanup of API service

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
