### PR TITLE
fix: remove the scheduling for combine pr action

### DIFF
--- a/.github/workflows/dependabot_combine_prs.yml
+++ b/.github/workflows/dependabot_combine_prs.yml
@@ -2,8 +2,6 @@ name: 'Dependabot combined PR'
 
 # Controls when the action will run - in this case it run on every midnight on the 1st day of every month  AND  it also can be triggered manually
 on:
-  schedule:
-    - cron: '0 0 1 * *'
   workflow_dispatch:
     inputs:
       branchPrefix:
@@ -161,7 +159,7 @@ jobs:
             await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'Combined PR',
+              title: 'Dependabot combined PR',
               head: '${{ github.event.inputs.combineBranchName }}',
               base: baseBranch,
               body: body


### PR DESCRIPTION
## Describe Changes

- Remove the scheduling for the `Dependabot_Combine_PR` action

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
