### PR TITLE
Feature / HOLO 663 disable some commands in cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,13 @@ ENV CONFIG_FILE=a-super-config-file.json
 ENV PASSWORD=a-super-secret-password
 ENV HOLOGRAPH_CLI_CMD=TeRmInAtOr
 ENV HOLOGRAPH_INDEXER_HOST=ThE_FuTuRe
-
+#
 ENV ENABLE_DEBUG=defaul-value
 ENV ENABLE_SYNC=defaul-value
 ENV HEALTHCHECK=defaul-value
 ENV MODE=defaul-value
+#
+ENV IS_UNSAFE=true
 
 # we use liveness/readiness probes in k8s
 HEALTHCHECK none

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ENV ENABLE_SYNC=defaul-value
 ENV HEALTHCHECK=defaul-value
 ENV MODE=defaul-value
 #
-ENV IS_UNSAFE=true
+ENV ENABLE_UNSAFE=defaul-value
 
 # we use liveness/readiness probes in k8s
 HEALTHCHECK none

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,13 +29,22 @@ else
   echo "HEALTHCHECK=${HEALTHCHECK}"
 fi
 
+if [[ $ENABLE_UNSAFE == 'true' ]] && [[ $ABI_ENVIRONMENT == "mainnet" ]]
+then
+  export ENABLE_UNSAFE='--unsafe'
+  echo "ENABLE_UNSAFE=${ENABLE_UNSAFE}"
+else
+  export ENABLE_UNSAFE=""
+  echo "ENABLE_UNSAFE=${ENABLE_UNSAFE}"
+fi
+
 # notice: configure
 holograph config --fromFile $CONFIG_FILE
 
 # notice: run the specified app
 if [[ $HOLO_CLI_CMD == "operator" ]]
 then
-  eval $ENABLE_DEBUG holograph $HOLO_CLI_CMD --env $HOLOGRAPH_ENVIRONMENT --networks $NETWORK --mode $MODE $ENABLE_SYNC $HEALTHCHECK --unsafePassword $PASSWORD --unsafe=$IS_UNSAFE
+  eval $ENABLE_DEBUG holograph $HOLO_CLI_CMD --env $HOLOGRAPH_ENVIRONMENT --networks $NETWORK --mode $MODE $ENABLE_SYNC $HEALTHCHECK --unsafePassword $PASSWORD $ENABLE_UNSAFE
 
 elif [[ $HOLO_CLI_CMD == "propagator" ]]
 then
@@ -43,7 +52,7 @@ then
 
 elif [[ $HOLO_CLI_CMD == "indexer" ]]
 then
-  eval $ENABLE_DEBUG holograph $HOLO_CLI_CMD --env $HOLOGRAPH_ENVIRONMENT --networks $NETWORK --host=$HOLO_INDEXER_HOST $HEALTHCHECK --unsafe=$IS_UNSAFE
+  eval $ENABLE_DEBUG holograph $HOLO_CLI_CMD --env $HOLOGRAPH_ENVIRONMENT --networks $NETWORK --host=$HOLO_INDEXER_HOST $HEALTHCHECK $ENABLE_UNSAFE
 
 else
   echo

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ else
   echo "HEALTHCHECK=${HEALTHCHECK}"
 fi
 
-if [[ $ENABLE_UNSAFE == 'true' ]] && [[ $ABI_ENVIRONMENT == "mainnet" ]]
+if [[ $ENABLE_UNSAFE == 'true' ]] && [[ $HOLOGRAPH_ENVIRONMENT == "mainnet" ]]
 then
   export ENABLE_UNSAFE='--unsafe'
   echo "ENABLE_UNSAFE=${ENABLE_UNSAFE}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,7 +35,7 @@ holograph config --fromFile $CONFIG_FILE
 # notice: run the specified app
 if [[ $HOLO_CLI_CMD == "operator" ]]
 then
-  eval $ENABLE_DEBUG holograph $HOLO_CLI_CMD --env $HOLOGRAPH_ENVIRONMENT --networks $NETWORK --mode $MODE $ENABLE_SYNC $HEALTHCHECK --unsafePassword $PASSWORD
+  eval $ENABLE_DEBUG holograph $HOLO_CLI_CMD --env $HOLOGRAPH_ENVIRONMENT --networks $NETWORK --mode $MODE $ENABLE_SYNC $HEALTHCHECK --unsafePassword $PASSWORD --unsafe=$IS_UNSAFE
 
 elif [[ $HOLO_CLI_CMD == "propagator" ]]
 then
@@ -43,7 +43,7 @@ then
 
 elif [[ $HOLO_CLI_CMD == "indexer" ]]
 then
-  eval $ENABLE_DEBUG holograph $HOLO_CLI_CMD --env $HOLOGRAPH_ENVIRONMENT --networks $NETWORK --host=$HOLO_INDEXER_HOST $HEALTHCHECK
+  eval $ENABLE_DEBUG holograph $HOLO_CLI_CMD --env $HOLOGRAPH_ENVIRONMENT --networks $NETWORK --host=$HOLO_INDEXER_HOST $HEALTHCHECK --unsafe=$IS_UNSAFE
 
 else
   echo

--- a/src/hooks/init/environment-selector.ts
+++ b/src/hooks/init/environment-selector.ts
@@ -1,4 +1,5 @@
 import {Hook} from '@oclif/core'
+import color from '@oclif/color'
 
 enum Environment {
   EXPERIMENTAL = 'experimental',
@@ -7,8 +8,46 @@ enum Environment {
   MAINNET = 'mainnet',
 }
 
+function validateDisabledCommandsOnMainnet(environment: string, commandName: string, argv: string[]) {
+  const commandsDisableForMainnet = [
+    'faucet',
+    'operator',
+    'operator:bond',
+    'operator:unbond',
+    'operator:recover',
+    'indexer',
+  ]
+
+  const indexOfArg = argv.indexOf('--unsafe')
+  const unsafe = indexOfArg !== -1
+
+  if (environment === Environment.MAINNET && commandsDisableForMainnet.includes(commandName)) {
+    console.error(color.red(`The ${commandName} command is currently disabled on mainnet.`))
+
+    if (unsafe && (commandName.includes('operator') || commandName.includes('indexer'))) {
+      console.warn(color.yellow('Executing command on UNSAFE mode...'))
+      argv.splice(indexOfArg)
+    } else {
+      // eslint-disable-next-line no-process-exit, unicorn/no-process-exit
+      process.exit(0)
+    }
+  }
+}
+
+function validateDisabledCommands(commandName: string) {
+  const commandsDisableTemporarily = ['create', 'create:contract', 'create:nft']
+
+  if (commandsDisableTemporarily.includes(commandName)) {
+    console.error(color.red(`The ${commandName} command is temporarily disabled.`))
+    // eslint-disable-next-line no-process-exit, unicorn/no-process-exit
+    process.exit(0)
+  }
+}
+
 const environmentSelectorHook: Hook<'init'> = async function ({id, argv}) {
-  if (id !== 'config') {
+  validateDisabledCommands(String(id))
+
+  if (id !== 'config' && id !== undefined) {
     const indexOfEnv = argv.indexOf('--env')
 
     process.env.HOLOGRAPH_ENVIRONMENT = Environment.TESTNET
@@ -17,10 +56,12 @@ const environmentSelectorHook: Hook<'init'> = async function ({id, argv}) {
       const environment = argv[indexOfEnv + 1]
       argv.splice(indexOfEnv, 2)
 
+      validateDisabledCommandsOnMainnet(environment, id, argv)
+
       if ((Object.values(Environment) as string[]).includes(environment)) {
         process.env.HOLOGRAPH_ENVIRONMENT = environment
       } else {
-        this.log('WARNING: Environment not identified. Using "testnet"...')
+        this.log(color.yellow('WARNING: Environment not identified. Using "testnet"...'))
       }
     }
   }


### PR DESCRIPTION
## Describe Changes


- Change `hooks/init/environment-selector.ts`
    - Disable the `create` command;
    - Disable `faucet`, `operator`, and `indexer` commands on **mainnet**;
    - Add `--unsafe` flag on `operator` and `indexer` if the command is running on **mainnet**.
 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
