### PR TITLE
Hotfix/reenable structured logs in api service

### DIFF
--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -246,6 +246,10 @@ export default class Indexer extends HealthCheck {
 
   processDBJobs(timestamp?: number, job?: DBJob): void {
     if (timestamp !== undefined && job !== undefined) {
+      /*
+       * @dev Temporary addition to unblock other DB jobs from getting delayed when current DB job fails.
+       *      Remove this once proper Registry checks are implemented for cxipMint events.
+       */
       timestamp += 30
       if (!(timestamp in this.dbJobMap)) {
         this.networkMonitor.structuredLog(job.network, `Adding ${timestamp} to dbJobMap`, job.tags)

--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -246,7 +246,7 @@ export default class Indexer extends HealthCheck {
 
   processDBJobs(timestamp?: number, job?: DBJob): void {
     if (timestamp !== undefined && job !== undefined) {
-      timestamp += 30;
+      timestamp += 30
       if (!(timestamp in this.dbJobMap)) {
         this.networkMonitor.structuredLog(job.network, `Adding ${timestamp} to dbJobMap`, job.tags)
         this.dbJobMap[timestamp] = []

--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -150,8 +150,8 @@ export default class Indexer extends HealthCheck {
       warp: flags.warp,
     })
 
-    this.apiService.setStructuredLog(this.networkMonitor.structuredLog)
-    this.apiService.setStructuredLogError(this.networkMonitor.structuredLogError)
+    this.apiService.setStructuredLog(this.networkMonitor.structuredLog.bind(this.networkMonitor))
+    this.apiService.setStructuredLogError(this.networkMonitor.structuredLogError.bind(this.networkMonitor))
 
     // TODO: It doesn't seems like sync is working
     // Indexer always synchronizes missed blocks

--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -150,8 +150,8 @@ export default class Indexer extends HealthCheck {
       warp: flags.warp,
     })
 
-    this.apiService.setStructuredLog(this.networkMonitor.structuredLog.bind(this.networkMonitor))
-    this.apiService.setStructuredLogError(this.networkMonitor.structuredLogError.bind(this.networkMonitor))
+    this.apiService.setStructuredLog(this.networkMonitor.structuredLog)
+    this.apiService.setStructuredLogError(this.networkMonitor.structuredLogError)
 
     // TODO: It doesn't seems like sync is working
     // Indexer always synchronizes missed blocks
@@ -216,13 +216,6 @@ export default class Indexer extends HealthCheck {
       this.processDBJobs()
     } else {
       const structuredLogInfo = {network: job.network, tagId: job.tags}
-      this.networkMonitor.structuredLog(
-        job.network,
-        `Querying ${job.query} identifier ${JSON.stringify(job.identifier)} - arguments ${JSON.stringify(
-          job.arguments,
-        )}, `,
-        job.tags,
-      )
       try {
         response = await this.apiService.sendQueryRequest(job.query, job.identifier, structuredLogInfo)
         try {
@@ -253,6 +246,7 @@ export default class Indexer extends HealthCheck {
 
   processDBJobs(timestamp?: number, job?: DBJob): void {
     if (timestamp !== undefined && job !== undefined) {
+      timestamp += 30;
       if (!(timestamp in this.dbJobMap)) {
         this.networkMonitor.structuredLog(job.network, `Adding ${timestamp} to dbJobMap`, job.tags)
         this.dbJobMap[timestamp] = []
@@ -1261,6 +1255,7 @@ export default class Indexer extends HealthCheck {
     )
 
     this.networkMonitor.structuredLog(network, `Checking if contract ${contractAddress} is on registry ...`, tags)
+
     this.networkMonitor.structuredLog(
       network,
       `registry Contract address = ${this.networkMonitor.registryContract.address}`,

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -72,7 +72,6 @@ class ApiService {
   }
 
   async sendQueryRequest(query: string, props: any, structuredLogInfo?: StructuredLogInfo): Promise<any> {
-    process.stdout.write(JSON.stringify(structuredLogInfo))
     if (this.logger.structuredLog !== undefined && structuredLogInfo !== undefined) {
       this.logger.structuredLog(
         structuredLogInfo.network,
@@ -86,7 +85,6 @@ class ApiService {
     try {
       return await this.client.request(query, props)
     } catch (error: any) {
-      process.stdout.write(JSON.stringify(error))
       if (this.logger.structuredLogError !== undefined && structuredLogInfo !== undefined) {
         this.logger.structuredLogError(structuredLogInfo.network, error, [
           ...(structuredLogInfo.tagId as (string | number)[]),

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -73,28 +73,28 @@ class ApiService {
 
   async sendQueryRequest(query: string, props: any, structuredLogInfo?: StructuredLogInfo): Promise<any> {
     process.stdout.write(JSON.stringify(structuredLogInfo))
-    // if (this.logger.structuredLog !== undefined && structuredLogInfo !== undefined) {
-    //   this.logger.structuredLog(
-    //     structuredLogInfo.network,
-    //     `Sending query request ${query} with props ${JSON.stringify(props)}`,
-    //     structuredLogInfo.tagId,
-    //   )
-    // } else {
-    //   this.logger.log(`Sending query request ${query} with props ${JSON.stringify(props)}`)
-    // }
+    if (this.logger.structuredLog !== undefined && structuredLogInfo !== undefined) {
+      this.logger.structuredLog(
+        structuredLogInfo.network,
+        `Sending query request ${query} with props ${JSON.stringify(props)}`,
+        structuredLogInfo.tagId,
+      )
+    } else {
+      this.logger.log(`Sending query request ${query} with props ${JSON.stringify(props)}`)
+    }
 
     try {
       return await this.client.request(query, props)
     } catch (error: any) {
       process.stdout.write(JSON.stringify(error))
-      // if (this.logger.structuredLogError !== undefined && structuredLogInfo !== undefined) {
-      //   this.logger.structuredLogError(structuredLogInfo.network, error, [
-      //     ...(structuredLogInfo.tagId as (string | number)[]),
-      //     this.errorColor(`Error sending query request`),
-      //   ])
-      // } else {
-      //   this.logger.error(`Error sending query request ${error}`)
-      // }
+      if (this.logger.structuredLogError !== undefined && structuredLogInfo !== undefined) {
+        this.logger.structuredLogError(structuredLogInfo.network, error, [
+          ...(structuredLogInfo.tagId as (string | number)[]),
+          this.errorColor(`Error sending query request`),
+        ])
+      } else {
+        this.logger.error(`Error sending query request ${error}`)
+      }
     }
   }
 


### PR DESCRIPTION
## Describe Changes

- Bind this context to instantiation of structured logger
- Reenable structured logs and remove process.stdout.write

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
