### PR TITLE
Minor fix to logs to output correct network names instead of token names

### DIFF
--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -315,9 +315,7 @@ export default class Indexer extends HealthCheck {
         setTimeout(this.processDBJobs.bind(this), 1000)
       }
     } else {
-      if (job === undefined) {
-        this.log(`No timestamps found, setting timeout...`)
-      } else {
+      if (job !== undefined) {
         this.networkMonitor.structuredLog(job.network, `No timestamps found, setting timeout...`, job.tags)
       }
 

--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -37,7 +37,7 @@ export const warpFlag = {
 export const networksFlag = {
   networks: Flags.string({
     description: 'Space separated list of networks to use',
-    options: supportedShortNetworks,
+    options: supportedNetworks.concat(...supportedShortNetworks),
     required: false,
     multiple: true,
   }),
@@ -46,7 +46,7 @@ export const networksFlag = {
 export const networkFlag = {
   network: Flags.string({
     description: 'Name of network to use',
-    options: supportedShortNetworks,
+    options: supportedNetworks.concat(...supportedShortNetworks),
     multiple: false,
     required: false,
   }),

--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -638,7 +638,7 @@ export class NetworkMonitor {
         this.failoverWebSocketProvider(network, rpcEndpoint, subscribe)
       }
 
-      this.structuredLog(network, `Websocket is closed. Restarting connection for ${networks[network].shortKey}`)
+      this.structuredLog(network, `Websocket is closed. Restarting connection for ${networks[network].key}`)
       // terminate the existing websocket
       this.ws[network].terminate()
       restart()
@@ -646,7 +646,7 @@ export class NetworkMonitor {
   }
 
   failoverWebSocketProvider(network: string, rpcEndpoint: string, subscribe: boolean): void {
-    this.log('this.providers', networks[network].shortKey)
+    this.log('this.providers', networks[network].key)
     this.ws[network] = new WebSocket(rpcEndpoint)
     keepAlive({
       debug: this.debug,
@@ -1143,7 +1143,7 @@ export class NetworkMonitor {
     const timestampColor = color.keyword('green')
     this.log(
       `[${timestampColor(timestamp)}] [${this.parent.constructor.name}] [${this.networkColors[network](
-        capitalize(networks[network].shortKey),
+        capitalize(networks[network].key),
       )}]${cleanTags(tagId)} ${msg}`,
     )
   }
@@ -1170,7 +1170,7 @@ export class NetworkMonitor {
 
     this.warn(
       `[${timestampColor(timestamp)}] [${this.parent.constructor.name}] [${this.networkColors[network](
-        capitalize(networks[network].shortKey),
+        capitalize(networks[network].key),
       )}] [${errorColor('error')}]${cleanTags(tagId)} ${errorMessage}`,
     )
   }

--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -638,7 +638,7 @@ export class NetworkMonitor {
         this.failoverWebSocketProvider(network, rpcEndpoint, subscribe)
       }
 
-      this.structuredLog(network, `Websocket is closed. Restarting connection for ${networks[network].key}`)
+      this.structuredLog(network, `Websocket is closed. Restarting connection for ${networks[network].name}`)
       // terminate the existing websocket
       this.ws[network].terminate()
       restart()
@@ -646,7 +646,7 @@ export class NetworkMonitor {
   }
 
   failoverWebSocketProvider(network: string, rpcEndpoint: string, subscribe: boolean): void {
-    this.log('this.providers', networks[network].key)
+    this.log('this.providers', networks[network].name)
     this.ws[network] = new WebSocket(rpcEndpoint)
     keepAlive({
       debug: this.debug,
@@ -1143,7 +1143,7 @@ export class NetworkMonitor {
     const timestampColor = color.keyword('green')
     this.log(
       `[${timestampColor(timestamp)}] [${this.parent.constructor.name}] [${this.networkColors[network](
-        capitalize(networks[network].key),
+        capitalize(networks[network].name),
       )}]${cleanTags(tagId)} ${msg}`,
     )
   }
@@ -1170,7 +1170,7 @@ export class NetworkMonitor {
 
     this.warn(
       `[${timestampColor(timestamp)}] [${this.parent.constructor.name}] [${this.networkColors[network](
-        capitalize(networks[network].key),
+        capitalize(networks[network].name),
       )}] [${errorColor('error')}]${cleanTags(tagId)} ${errorMessage}`,
     )
   }

--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -37,7 +37,7 @@ export const warpFlag = {
 export const networksFlag = {
   networks: Flags.string({
     description: 'Space separated list of networks to use',
-    options: supportedNetworks.concat(...supportedShortNetworks),
+    options: [...supportedNetworks, ...supportedShortNetworks],
     required: false,
     multiple: true,
   }),
@@ -46,7 +46,7 @@ export const networksFlag = {
 export const networkFlag = {
   network: Flags.string({
     description: 'Name of network to use',
-    options: supportedNetworks.concat(...supportedShortNetworks),
+    options: [...supportedNetworks, ...supportedShortNetworks],
     multiple: false,
     required: false,
   }),


### PR DESCRIPTION
## Describe Changes

- Update logs to output network name instead of token name
- Clean up some extraneous logs in the indexer

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
