### PR TITLE
Set the testnet/mainnet cicd with updated helm chart for the new dd tags

### DIFF
--- a/.github/workflows/cicd_develop_staging.yaml
+++ b/.github/workflows/cicd_develop_staging.yaml
@@ -10,13 +10,7 @@ env:
   ECR_REPOSITORY: holo-cli-dev # notice: the same for all cli apps
   #
   DEV_IMAGE_TAG: dev-${{ github.sha }}
-  #######################################
-  STG_HOLOGRAPH_INDEXER_HELM_CHART_VERSION: 0.0.68
-  INDEXER_RELEASE_NAME : indexer-dev  # format -> [release_name]-indexer-[env]
   #
-  STG_HOLOGRAPH_OPERATOR_HELM_CHART_VERSION: 0.0.54
-  OPERATOR_RELEASE_NAME: operator-dev # format -> [release_name]-operator-[env]
-  #######################################
   CLUSTER_NAME: staging
   #
   AWS_KEY_ID: ${{ secrets.NEWSTAGE_USER_AWS_ACCESS_KEY_ID }}
@@ -38,7 +32,15 @@ env:
   #
   STG_DOMAIN: 'cxipchain.xyz'
   #
-  STG_COMMON_NAMESPACE: develop
+  STG_COMMON_NAMESPACE: develop # NOTICE <---
+  #
+  #######################################
+  STG_HOLOGRAPH_INDEXER_HELM_CHART_VERSION: 0.0.68
+  INDEXER_RELEASE_NAME: indexer-dev  # format -> [release_name]-indexer-[env]
+  #
+  STG_HOLOGRAPH_OPERATOR_HELM_CHART_VERSION: 0.0.54
+  OPERATOR_RELEASE_NAME: operator-dev # format -> [release_name]-operator-[env]
+  #######################################
   #
   # INDEXER DEV rpc endpoints
   indexer_dev_avalancheTestnet_rpc_url: ${{ secrets.INDEXER_DEV_FUJI_RPC_URL }}
@@ -67,6 +69,7 @@ on:
 
 jobs:
   deploy-to-staging:
+
     name: Deploy-to-staging[dev]
     runs-on: ubuntu-latest
 
@@ -93,7 +96,7 @@ jobs:
         run: docker push ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ env.DEV_IMAGE_TAG }}
 
       - name: Configure AWS creds to access EKS
-        # notice: TIP: the deployment user must be in the masters group in the aws-auth config map in the cluster
+        # TIP: the deployment user must be in the masters group in the aws-auth config map in the cluster
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ env.AWS_KEY_ID }} #notice: unique for each env
@@ -119,14 +122,16 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           helm pull oci://$ECR_REGISTRY/$CHART_REPO --version $CHART_VERSION
-
+      ######
       - name: -> Deploy INDEXER cli in staging [namespace -> ${{ env.STG_COMMON_NAMESPACE }}]
         uses: tensor-hq/eksctl-helm-action@main
         env:
           RELEASE_NAME: ${{ env.INDEXER_RELEASE_NAME }} # notice
+          #
           ENABLE_DEBUG: 'true'
           HEALTHCHECK: 'true'
           MODE: 'auto'
+          ENABLE_UNSAFE: 'false'
           NETWORK: 'fuji mumbai goerli'
         with:
           eks_cluster: ${{ env.CLUSTER_NAME }}
@@ -134,6 +139,7 @@ jobs:
             helm upgrade --install $RELEASE_NAME \
             holo-indexer-${{ env.STG_HOLOGRAPH_INDEXER_HELM_CHART_VERSION }}.tgz \
             -n ${{ env.STG_COMMON_NAMESPACE }} \
+            /
             --set image.repository=${{ env.ECR_REPOSITORY }} \
             --set image.image_tag=${{ env.DEV_IMAGE_TAG }} \
             --set config_file_data=${{ env.INDEXER_HOLOGRAPH_CONFIG_FILE_DATA }} \
@@ -146,6 +152,7 @@ jobs:
             --set HEALTHCHECK=$HEALTHCHECK \
             --set MODE=$MODE \
             --set NETWORK="${NETWORK}" \
+            --set ENABLE_UNSAFE="${ENABLE_UNSAFE}" \
             \
             --set dev_rpc_config_values.avalancheTestnet_rpc_url=${{ env.indexer_dev_avalancheTestnet_rpc_url }} \
             --set dev_rpc_config_values.polygonTestnet_rpc_url=${{ env.indexer_dev_polygonTestnet_rpc_url }} \
@@ -153,10 +160,14 @@ jobs:
             \
             --set dev_rpc_config_values.private_key=${{ env.indexer_dev_private_key }} \
             --set dev_rpc_config_values.address=${{ env.indexer_dev_address }} \
+            --set testnet_rpc_config_values.version="beta3" \
             \
             --set datadog_tags.env=${{ env.CLUSTER_NAME }} \
             --set datadog_tags.service=$RELEASE_NAME \
             --set datadog_tags.version=chart-${{ env.STG_HOLOGRAPH_INDEXER_HELM_CHART_VERSION }} \
+            \
+            --set autoscaling.minReplicas=1 \
+            --set autoscaling.maxReplicas=1 \
             \
             --values .github/values_for_stg_alb_ingress.yaml \
             --set ingress.annotations."alb\.ingress\.kubernetes\.io/certificate-arn"='${{ env.ALB_CERT_ARN }}' \
@@ -177,21 +188,24 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           helm pull oci://$ECR_REGISTRY/$CHART_REPO --version $CHART_VERSION
-
+      ######
       - name: -> Deploy OPERATOR cli in staging [namespace -> ${{ env.STG_COMMON_NAMESPACE }}]
         uses: tensor-hq/eksctl-helm-action@main
         env:
           RELEASE_NAME: ${{ env.OPERATOR_RELEASE_NAME }} # notice
+          #
           ENABLE_DEBUG: 'true'
           ENABLE_SYNC: 'true'
           HEALTHCHECK: 'true'
           MODE: 'auto'
+          ENABLE_UNSAFE: 'false'
         with:
           eks_cluster: ${{ env.CLUSTER_NAME }}
           command: |-
             helm upgrade --install $RELEASE_NAME \
             holo-operator-${{ env.STG_HOLOGRAPH_OPERATOR_HELM_CHART_VERSION }}.tgz \
             -n ${{ env.STG_COMMON_NAMESPACE }} \
+            \
             --set image.repository=${{ env.ECR_REPOSITORY }} \
             --set image.image_tag=${{ env.DEV_IMAGE_TAG }} \
             --set config_file_data=${{ env.OPERATOR_HOLOGRAPH_CONFIG_FILE_DATA }} \
@@ -202,6 +216,7 @@ jobs:
             --set ENABLE_SYNC=$ENABLE_SYNC \
             --set HEALTHCHECK=$HEALTHCHECK \
             --set MODE=$MODE \
+            --set ENABLE_UNSAFE="${ENABLE_UNSAFE}" \
             \
             --set dev_rpc_config_values.avalancheTestnet_rpc_url=${{ env.operator_dev_avalancheTestnet_rpc_url }} \
             --set dev_rpc_config_values.polygonTestnet_rpc_url=${{ env.operator_dev_polygonTestnet_rpc_url }} \
@@ -230,7 +245,7 @@ jobs:
         with:
           eks_cluster: ${{ env.CLUSTER_NAME }}
           command: |-
-            echo "------------------------- Last 5 Helm releases -------------------------"
+            echo "------------------------- Last n Helm releases -------------------------"
             echo "--INDEXER--"
             helm history $INDEXER_RELEASE_NAME  -n ${{ env.STG_COMMON_NAMESPACE }} --max 3
             echo "--OPERATOR--"

--- a/.github/workflows/cicd_mainnet_prod.yaml
+++ b/.github/workflows/cicd_mainnet_prod.yaml
@@ -10,10 +10,7 @@ env:
   ECR_REPOSITORY: holo-cli # notice: the same for all cli apps
   #
   MAINNET_IMAGE_TAG: mainnet-${{ github.sha }}
-  ########################################
-  MAINNET_HOLO_INDEXER_HELM_CHART_VERSION: 0.0.59
-  MAINNET_HOLO_OPERATOR_HELM_CHART_VERSION: 0.0.51
-  ########################################
+  #
   CLUSTER_NAME: prod0
   #
   AWS_KEY_ID: ${{ secrets.PROD0_CICD_USER_AWS_ACCESS_KEY_ID }}
@@ -36,6 +33,14 @@ env:
   MAINNET_DOMAIN: 'holograph.xyz'
   #
   MAINNET_COMMON_NAMESPACE: mainnet # NOTICE <---
+  #
+  #######################################
+  MAINNET_HOLO_INDEXER_HELM_CHART_VERSION: 0.0.68
+  INDEXER_RELEASE_NAME : rhea-indexer-mainnet  # format -> [release_name]-indexer-[env]
+  #
+  MAINNET_HOLO_OPERATOR_HELM_CHART_VERSION: 0.0.54
+  OPERATOR_RELEASE_NAME: rhea-operator-mainnet # format -> [release_name]-operator-[env]
+  #######################################
   #
   ### INDEXER MAINNET rpc endpoints
   indexer_mainnet_avalanche_rpc_url: ${{ secrets.INDEXER_MAINNET_AVALANCHE_RPC_URL }}
@@ -127,7 +132,7 @@ jobs:
       - name: -> Deploy INDEXER cli in MAINNET [namespace -> ${{ env.MAINNET_COMMON_NAMESPACE }}]
         uses: tensor-hq/eksctl-helm-action@main
         env:
-          RELEASE_NAME: indexer-main # notice
+          RELEASE_NAME: ${{ env.INDEXER_RELEASE_NAME }} # notice
           #
           ENABLE_DEBUG: 'true'
           HEALTHCHECK: 'true'
@@ -181,7 +186,7 @@ jobs:
       #
       #
       # NOTICE: --- OPERATOR ---
-      - name: Pull the holo-operator helm chart version x.x.x from ECR
+      - name: Pull the holograph-operator helm chart version x.x.x from ECR
         shell: bash
         env:
           #
@@ -195,7 +200,7 @@ jobs:
       - name: -> Deploy OPERATOR cli in MAINNET [namespace -> ${{ env.MAINNET_COMMON_NAMESPACE }}]
         uses: tensor-hq/eksctl-helm-action@main
         env:
-          RELEASE_NAME: operator-main # notice
+          RELEASE_NAME: ${{ env.OPERATOR_RELEASE_NAME }} # notice
           #
           ENABLE_DEBUG: 'true'
           ENABLE_SYNC: 'true'
@@ -236,6 +241,7 @@ jobs:
             --set mainnet_rpc_config_values.address=${{ env.operator_mainnet_address }} \
             \
             --set datadog_tags.env=${{ env.CLUSTER_NAME }} \
+            --set datadog_tags.service=$RELEASE_NAME \
             --set datadog_tags.version=chart-${{ env.MAINNET_HOLO_OPERATOR_HELM_CHART_VERSION }} \
             \
             --values .github/values_for_prod_alb_ingress.yaml \
@@ -248,8 +254,8 @@ jobs:
       - name: -> Info for the new deployments
         uses: tensor-hq/eksctl-helm-action@main
         env:
-          INDEXER_RELEASE_NAME: indexer-main
-          OPERATOR_RELEASE_NAME: operator-main
+          INDEXER_RELEASE_NAME : ${{ env.INDEXER_RELEASE_NAME }}
+          OPERATOR_RELEASE_NAME: ${{ env.OPERATOR_RELEASE_NAME }}
           LB_URL: 'https://prod0-alb-1736382478.us-west-2.elb.amazonaws.com'
         with:
           eks_cluster: ${{ env.CLUSTER_NAME }}

--- a/.github/workflows/cicd_testnet_prod.yaml
+++ b/.github/workflows/cicd_testnet_prod.yaml
@@ -10,18 +10,14 @@ env:
   ECR_REPOSITORY: holo-cli # notice: the same for all cli apps
   #
   TESTNET_IMAGE_TAG: testnet-${{ github.sha }}
-  #######################################
-  TESTNET_HOLO_INDEXER_HELM_CHART_VERSION: 0.0.59
-  TESTNET_HOLO_OPERATOR_HELM_CHART_VERSION: 0.0.51
-  #######################################
+  #
   CLUSTER_NAME: prod0
   #
   AWS_KEY_ID: ${{ secrets.PROD0_CICD_USER_AWS_ACCESS_KEY_ID }}
   AWS_ACCESS_KEY: ${{ secrets.PROD0_CICD_USER_AWS_SECRET_ACCESS_KEY }}
   ALB_CERT_ARN: ${{ secrets.PROD_ALB_CERT_ARN_FOR_HOLOGRAPH_XYZ }} # TIP: the 2 CERTs are separated with \, in Github secret
   #
-  #TODO - create new gh secret for TESTNET. should be different from staging????
-  TESTNET_HOLO_INDEXER_OPERATOR_API_KEY: ${{ secrets.HOLO_INDEXER_OPERATOR_API_KEY }}
+  TESTNET_HOLO_INDEXER_OPERATOR_API_KEY: ${{ secrets.HOLO_INDEXER_OPERATOR_API_KEY }} #TODO - create new gh secret for TESTNET. should be different from staging????
   #
   TESTNET_HOLO_INDEXER_HOST: 'http://testrhea-holo-api.testnet.svc.cluster.local:443' # Notice <-- the release from API
   #
@@ -37,6 +33,14 @@ env:
   TESTNET_DOMAIN: 'holograph.xyz'
   #
   TESTNET_COMMON_NAMESPACE: testnet # NOTICE <---
+  #
+  #######################################
+  TESTNET_HOLO_INDEXER_HELM_CHART_VERSION: 0.0.68
+  INDEXER_RELEASE_NAME : rhea-indexer-testnet  # format -> [release_name]-indexer-[env]
+  #
+  TESTNET_HOLO_OPERATOR_HELM_CHART_VERSION: 0.0.54
+  OPERATOR_RELEASE_NAME: rhea-operator-testnet # format -> [release_name]-operator-[env]
+  #######################################
   #
   # INDEXER TESTNET rpc endpoints
   indexer_testnet_avalancheTestnet_rpc_url: ${{ secrets.INDEXER_PROD_FUJI_RPC_URL }}
@@ -128,7 +132,7 @@ jobs:
       - name: -> Deploy INDEXER cli in TESTNET [namespace -> ${{ env.TESTNET_COMMON_NAMESPACE }}]
         uses: tensor-hq/eksctl-helm-action@main
         env:
-          RELEASE_NAME: rhea-indexer-testnet # notice
+          RELEASE_NAME: ${{ env.INDEXER_RELEASE_NAME }} # notice
           #
           ENABLE_DEBUG: 'true'
           HEALTHCHECK: 'true'
@@ -165,7 +169,7 @@ jobs:
             --set testnet_rpc_config_values.version="beta3" \
             \
             --set datadog_tags.env=${{ env.CLUSTER_NAME }} \
-            --set datadog_tags.service=$RELEASE_NAME-holo-indexer \
+            --set datadog_tags.service=$RELEASE_NAME \
             --set datadog_tags.version=chart-${{ env.TESTNET_HOLO_INDEXER_HELM_CHART_VERSION }} \
             \
             --set autoscaling.minReplicas=1 \
@@ -180,7 +184,7 @@ jobs:
       #
       #
       # NOTICE: --- OPERATOR ---
-      - name: Pull the holo-operator helm chart version x.x.x from ECR
+      - name: Pull the holograph-operator helm chart version x.x.x from ECR
         shell: bash
         env:
           #
@@ -194,7 +198,7 @@ jobs:
       - name: -> Deploy OPERATOR cli in TESTNET [namespace -> ${{ env.TESTNET_COMMON_NAMESPACE }}]
         uses: tensor-hq/eksctl-helm-action@main
         env:
-          RELEASE_NAME: rhea-operator-testnet # notice
+          RELEASE_NAME: ${{ env.OPERATOR_RELEASE_NAME }} # notice
           #
           ENABLE_DEBUG: 'true'
           ENABLE_SYNC: 'true'
@@ -235,6 +239,7 @@ jobs:
             --set testnet_rpc_config_values.address=${{ env.operator_testnet_address }} \
             \
             --set datadog_tags.env=${{ env.CLUSTER_NAME }} \
+            --set datadog_tags.service=$RELEASE_NAME \
             --set datadog_tags.version=chart-${{ env.TESTNET_HOLO_OPERATOR_HELM_CHART_VERSION }} \
             \
             --values .github/values_for_prod_alb_ingress.yaml \
@@ -247,8 +252,8 @@ jobs:
       - name: -> Info for the new deployments
         uses: tensor-hq/eksctl-helm-action@main
         env:
-          INDEXER_RELEASE_NAME: rhea-indexer-testnet
-          OPERATOR_RELEASE_NAME: rhea-operator-testnet
+          INDEXER_RELEASE_NAME : ${{ env.INDEXER_RELEASE_NAME }}
+          OPERATOR_RELEASE_NAME: ${{ env.OPERATOR_RELEASE_NAME }}
           LB_URL: 'https://prod0-alb-1736382478.us-west-2.elb.amazonaws.com'
         with:
           eks_cluster: ${{ env.CLUSTER_NAME }}


### PR DESCRIPTION
## Describe Changes

I made this better by doing ...

- Develop cicd: Minor cosmetic changes, so the cicd file will be in uniform with the others. 
- Testnet cicd: Cosmetic changes so the release naming is clearer
- Mainnet cicd: Changed the release names for indexer/operators with the new naming convention that helps separate the different releases in datadog. The new releases will not affect the old ones. After confirming that all is good, I'll scaled own the old ones.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
