### PR TITLE
Exit out of process if a request for an operator token fails

### DIFF
--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -95,8 +95,10 @@ export default class Indexer extends HealthCheck {
         this.apiService = new ApiService(this.BASE_URL, logger)
         await this.apiService.operatorLogin()
       } catch (error: any) {
+        this.log('Error: Failed to get Operator Token from API')
         // NOTE: sample of how to do logs when in production mode
         this.log(JSON.stringify({...error, stack: error.stack}))
+        this.exit()
       }
 
       if (this.apiService === undefined) {

--- a/src/services/api-service.ts
+++ b/src/services/api-service.ts
@@ -88,7 +88,7 @@ class ApiService {
     }
 
     this.client.setHeader('authorization', `Bearer ${JWT}`)
-    this.logger.log(`Operator JWT: ${JWT}`)
+    // this.logger.log(`Operator JWT: ${JWT}`)
   }
 
   async sendQueryRequest<T = any>(


### PR DESCRIPTION
## Describe Changes

I made this better by doing ...

- Remove logs of the JWT token
- Stop indexer from running if the request for an operator token fails

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
