### PR TITLE
bugfix: enable block height update via API on only the indexer and op…

### DIFF
--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -980,7 +980,9 @@ export class NetworkMonitor {
         this.structuredLog(job.network, `Block processing complete ✅`, job.block)
       }
 
-      this.updateLastProcessedBlock(job)
+      if (this.parent.id === 'indexer' || this.parent.id === 'operator') {
+        this.updateLastProcessedBlock(job)
+      }
 
       this.blockJobs[job.network].shift()
     }


### PR DESCRIPTION

## Describe Changes

Change the network monitor to check the command name before `updateLastProcessedBlock`.


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
