### PR TITLE
Feature / HOLO 960 rename repair to replay

### DIFF
--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -25,7 +25,7 @@ import {
   FailedOperatorJobEvent,
 } from '../../utils/event'
 
-import {BlockJob, NetworkMonitor, networksFlag, repairFlag} from '../../utils/network-monitor'
+import {BlockJob, NetworkMonitor, networksFlag, replayFlag} from '../../utils/network-monitor'
 import {zeroAddress} from '../../utils/utils'
 import {HealthCheck} from '../../base-commands/healthcheck'
 import {ensureConfigFileIsValid} from '../../utils/config'
@@ -59,7 +59,7 @@ export default class Indexer extends HealthCheck {
     ...syncFlag,
     ...blockHeightFlag,
     ...networksFlag,
-    ...repairFlag,
+    ...replayFlag,
     ...HealthCheck.flags,
   }
 
@@ -93,8 +93,8 @@ export default class Indexer extends HealthCheck {
 
     this.environment = environment
 
-    if (flags.repair > 0) {
-      this.log('Repair flag enabled, will not load or save block heights.')
+    if (flags.replay > 0) {
+      this.log('Replay flag enabled, will not load or save block heights.')
       updateBlockHeight = BlockHeightOptions.DISABLE
     }
 
@@ -134,7 +134,7 @@ export default class Indexer extends HealthCheck {
       debug: this.debug,
       processTransactions2: this.processTransactions2,
       lastBlockFilename: 'indexer-blocks.json',
-      repair: flags.repair,
+      replay: flags.replay,
       apiService: this.apiService,
       BlockHeightOptions: updateBlockHeight as BlockHeightOptions,
     })
@@ -184,7 +184,7 @@ export default class Indexer extends HealthCheck {
     }
 
     CliUx.ux.action.start(`Starting indexer`)
-    const continuous = !flags.repair // If repair is set, run network monitor stops after catching up to the latest block
+    const continuous = !flags.replay // If replay is set, run network monitor stops after catching up to the latest block
     await this.networkMonitor.run(continuous, undefined, this.filterBuilder2)
     CliUx.ux.action.stop('🚀')
 


### PR DESCRIPTION
## Describe Changes

- rename the flag `--repair` to be `--replay`
- emit deprecation warning anytime `--repair` is used

<img width="983" alt="image" src="https://user-images.githubusercontent.com/37748828/236284717-e35ba0b3-c0c3-454b-bc49-f8e909691c4f.png">


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
