### PR TITLE
HOLO-969: Prevent Network Monitor from getting stuck in some blocks

### DIFF
--- a/src/utils/extended-block.ts
+++ b/src/utils/extended-block.ts
@@ -57,8 +57,14 @@ export const getExtendedBlockWithTransactions = async (
   provider: WebSocketProvider | JsonRpcProvider,
   blockNumber: number,
 ): Promise<ExtendedBlockWithTransactions | null> => {
-  const rawBlock: any = await provider.send('eth_getBlockByNumber', [blockNumber.hexify(null, true), true])
-  if (rawBlock === null) {
+  let rawBlock: any
+  try {
+    rawBlock = await provider.send('eth_getBlockByNumber', [blockNumber.hexify(null, true), true])
+    if (rawBlock === null) {
+      return null
+    }
+  } catch (error: any) {
+    console.log(`Error getting extended block ${blockNumber}: ${error.message}`)
     return null
   }
 

--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -1542,7 +1542,13 @@ export class NetworkMonitor {
     interval = 10_000,
   }: LogsParams): Promise<Log[] | null> {
     const targetBlock: string = BigNumber.from(blockNumber).toHexString()
-    const filter: Filter = {fromBlock: targetBlock, toBlock: targetBlock}
+    const topicsArray = this.bloomFilters.map(bloomFilter => bloomFilter.bloomValueHashed)
+
+    const filter: Filter = {
+      fromBlock: targetBlock,
+      toBlock: targetBlock,
+      topics: [topicsArray], // topics array needs to be wrapped in a nested array
+    }
 
     const getLogs = async () => {
       try {

--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -1374,14 +1374,14 @@ export class NetworkMonitor {
   }
 
   async processBlock2(job: BlockJob): Promise<void> {
-    let interestingTransactions: InterestingTransaction[] = []
+    const interestingTransactions: InterestingTransaction[] = []
     this.activated[job.network] = true
     if (this.verbose) {
       this.structuredLog(job.network, `Getting block 🔍`, job.block)
     }
 
     try {
-      let block = await this.getBlockWithTransactions({
+      const block = await this.getBlockWithTransactions({
         network: job.network,
         blockNumber: job.block,
         attempts: 10,
@@ -1423,7 +1423,7 @@ export class NetworkMonitor {
       this.structuredLogError(job.network, `Error processing block ${error}`, job.block)
     } finally {
       try {
-        return await this.blockJobHandler(job.network, job)
+        await this.blockJobHandler(job.network, job)
       } catch (error: any) {
         this.structuredLogError(job.network, `Error handling block ${error}`, job.block)
       }

--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -1568,8 +1568,7 @@ export class NetworkMonitor {
     try {
       return await this.retry(network, getLogs, attempts, interval)
     } catch (error) {
-      // If retry was not successful, handle it accordingly.
-      console.error(`Error retrieving logs after ${attempts} attempts:`, error)
+      this.structuredLogError(network, `Error retrieving logs after ${attempts} attempts: ${error}`, tags)
       return null
     }
   }


### PR DESCRIPTION
## Describe Changes

- Added try/catch block to calls to async functions to ensure promises are resolved/rejected
- Speed up getLogs by filtering by topics
- Updated retry function so it throws an error instead of running indefinitely if max attempts is exceeded
- Added some additional logging

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
