### PR TITLE
improvement/operator recover file now can read a file.

### DIFF
--- a/src/commands/operator/recover.ts
+++ b/src/commands/operator/recover.ts
@@ -60,7 +60,7 @@ export default class Recover extends OperatorJobAwareCommand {
       options: Object.values(OperatorMode),
       char: 'm',
     }),
-    updateDB: Flags.boolean({
+    'update-db': Flags.boolean({
       description: 'Update the DB with the status of the bridge that was being processed',
       dependsOn: ['host'],
     }),

--- a/src/commands/operator/recover.ts
+++ b/src/commands/operator/recover.ts
@@ -60,6 +60,10 @@ export default class Recover extends OperatorJobAwareCommand {
       options: Object.values(OperatorMode),
       char: 'm',
     }),
+    updateDB: Flags.boolean({
+      description: 'Update the DB with the status of the bridge that was being processed',
+      dependsOn: ['host'],
+    }),
     ...HealthCheck.flags,
   }
 
@@ -366,9 +370,9 @@ export default class Recover extends OperatorJobAwareCommand {
       })
 
       // Manually disabled this as its only needed if indexer is not running when this is processed
-      // if (response !== null && response.status === 1) {
-      //   await this.updateDB(network, sha3(payload), step)
-      // }
+      if (response !== null && response.status === 1 && this.updateDB) {
+        await this.updateDB(network, sha3(payload), step)
+      }
     }
   }
 

--- a/src/commands/operator/recover.ts
+++ b/src/commands/operator/recover.ts
@@ -7,8 +7,8 @@ import {TransactionDescription} from '@ethersproject/abi'
 import {networks, supportedNetworks} from '@holographxyz/networks'
 
 import {ensureConfigFileIsValid} from '../../utils/config'
-import { NetworkMonitor, OperatorMode } from "../../utils/network-monitor";
-import { chainIdToNetwork, networkToChainId, sha3 } from "../../utils/utils";
+import {NetworkMonitor, OperatorMode} from '../../utils/network-monitor'
+import {chainIdToNetwork, networkToChainId, sha3} from '../../utils/utils'
 import {checkOptionFlag, checkTransactionHashFlag} from '../../utils/validation'
 import {OperatorJobAwareCommand} from '../../utils/operator-job'
 import {HealthCheck} from '../../base-commands/healthcheck'
@@ -43,16 +43,17 @@ export default class Recover extends OperatorJobAwareCommand {
     network: Flags.string({
       description: 'The network on which the transaction was executed',
       options: supportedNetworks,
-      dependsOn: ['tx']
+      dependsOn: ['tx'],
     }),
     tx: Flags.string({
       description: 'The hash of transaction that we want to attempt to execute',
-      dependsOn: ['network']
+      dependsOn: ['network'],
     }),
     file: Flags.string({
-     char: 'f',
-     description: 'JSON file path of incomplete jobs (ie "./incompleteJobs.json") in format [{ source_tx, source_chain_id}]',
-     exclusive: ['tx']
+      char: 'f',
+      description:
+        'JSON file path of incomplete jobs (ie "./incompleteJobs.json") in format [{ source_tx, source_chain_id}]',
+      exclusive: ['tx'],
     }),
     mode: Flags.string({
       description: 'The mode in which to run the operator',
@@ -77,11 +78,7 @@ export default class Recover extends OperatorJobAwareCommand {
   async run(): Promise<void> {
     this.log('Loading user configurations...')
 
-    const {userWallet, configFile} = await ensureConfigFileIsValid(
-      this.config.configDir,
-      undefined,
-      true,
-    )
+    const {userWallet, configFile} = await ensureConfigFileIsValid(this.config.configDir, undefined, true)
     this.log('User configurations loaded.')
 
     const {flags} = await this.parse(Recover)
@@ -93,7 +90,7 @@ export default class Recover extends OperatorJobAwareCommand {
           flags.mode,
           'Select the mode in which to run the operator',
         )) as keyof typeof OperatorMode
-        ]
+      ]
 
     this.log(`Operator mode: ${this.operatorMode}`)
 
@@ -149,7 +146,7 @@ export default class Recover extends OperatorJobAwareCommand {
 
     let txArray = []
     // If network and tx flags are provided, construct an array of one element
-    if(!!flags.network || !!flags.tx) {
+    if (Boolean(flags.network) || Boolean(flags.tx)) {
       const flagNetwork: string = await checkOptionFlag(
         supportedNetworks,
         flags.network,
@@ -161,8 +158,7 @@ export default class Recover extends OperatorJobAwareCommand {
         'Enter the hash of transaction from which to extract recovery data from',
       )
 
-      txArray = [{ sourceChainId: networkToChainId[flagNetwork], sourceTx: flagTx }]
-
+      txArray = [{sourceChainId: networkToChainId[flagNetwork], sourceTx: flagTx}]
     } else {
       if (!(await fs.pathExists(flags.file as string))) {
         this.error(`Problem reading ${flags.file}`)
@@ -171,7 +167,7 @@ export default class Recover extends OperatorJobAwareCommand {
       let incompleteJobs: IncompleteJobs[] = []
       try {
         incompleteJobs = (await fs.readJson(flags.file as string)) as IncompleteJobs[]
-        //TODO: add validation of the file
+        // TODO: add validation of the file
       } catch {
         this.error(`One or more lines are an invalid Incomplete jobs JSON object`)
       }
@@ -179,7 +175,7 @@ export default class Recover extends OperatorJobAwareCommand {
       txArray = incompleteJobs.map(item => {
         return {
           sourceChainId: item.source_chain_id,
-          sourceTx: item.source_tx
+          sourceTx: item.source_tx,
         }
       })
     }

--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -430,7 +430,7 @@ export class NetworkMonitor {
     }
   }
 
-  validateReplayFlagInput(input: string) {
+  validateReplayFlagInput(input: string): boolean {
     if (/([1-9]\d*|0):([1-9]\d*)/.test(input)) {
       // expected type: 8987:8988
       const startAndEndBlock = input.split(':').map(int => Number(int))

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -55,10 +55,8 @@ export const networkToChainId: Record<string, number> = {
 
 // NOTE: This is an inverse map of networkToChainId
 export const chainIdToNetwork = (): Record<number, string> => {
-  const flipped = Object
-    .entries(networkToChainId)
-    .map(([key, value]) => [value, key]);
-  return Object.fromEntries(flipped);
+  const flipped = Object.entries(networkToChainId).map(([key, value]) => [value, key])
+  return Object.fromEntries(flipped)
 }
 
 export const NETWORK_COLORS: Record<string, string> = {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -53,6 +53,14 @@ export const networkToChainId: Record<string, number> = {
   arbitrum: 42_161,
 }
 
+// NOTE: This is an inverse map of networkToChainId
+export const chainIdToNetwork = (): Record<number, string> => {
+  const flipped = Object
+    .entries(networkToChainId)
+    .map(([key, value]) => [value, key]);
+  return Object.fromEntries(flipped);
+}
+
 export const NETWORK_COLORS: Record<string, string> = {
   localhost: '#83EEFF',
   localhost2: '#ff0000',

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -230,7 +230,7 @@ export function generateHashedName(name: string): string {
   return `0x${paddedHex}`
 }
 
-export function safeStringify(obj: any, indent = 2) {
+export function safeStringify(obj: any, indent = 2): string {
   let cache: any[] = []
   const retVal = JSON.stringify(
     obj,


### PR DESCRIPTION
## Describe Changes

I made this better by doing ...

- Added `--file` flag 
- The `--file` is exclusive to `--tx` and `--network` flags
- the `--tx` and `--network` flags now depend on each other.
- we can now process an array of jobs to complete.
- Added `--mode` flag to recover command
- changed `--network` flag to use regular network name instead of short name. aka `binanceSmartChain` instead of `bnb`
- Added `--update-db` flag 

## Examples

1. `./bin/dev operator:recover --mode auto --file ./bnb_incomplete.json`
2. `./bin/dev --tx 0xb8953b8a6fe663cfde331aa28659c6ce293087c55fe96d3d0a91a6ef0d0f252b --network binanceSmartChain --mode auto
`


## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Code styles have been enforced
- [ ] I have checked eslint
