### PR TITLE
Fix the bug where env selector hook was overriding .env file

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,11 +1,6 @@
 #!/usr/bin/env node
 
-require('dotenv').config();
-
-const env = process.env.ABI_ENVIRONMENT || process.env.HOLOGRAPH_ENVIRONMENT || '';
-if (env === '') {
-  process.env.HOLOGRAPH_ENVIRONMENT = 'experimental';
-}
+require('dotenv').config()
 
 const oclif = require('@oclif/core')
 
@@ -18,7 +13,7 @@ process.env.NODE_ENV = 'development'
 require('ts-node').register({project})
 
 // In dev mode, always show stack traces
-oclif.settings.debug = true;
+oclif.settings.debug = true
 
 // Start the CLI
 oclif.run().then(oclif.flush).catch(oclif.Errors.handle)

--- a/bin/run
+++ b/bin/run
@@ -1,12 +1,5 @@
 #!/usr/bin/env node
 
-require('dotenv').config();
-
-const env = process.env.ABI_ENVIRONMENT || process.env.HOLOGRAPH_ENVIRONMENT || '';
-if (env === '') {
-  process.env.HOLOGRAPH_ENVIRONMENT = 'experimental';
-}
-
 const oclif = require('@oclif/core')
 
 oclif.run().then(require('@oclif/core/flush')).catch(require('@oclif/core/handle'))

--- a/src/hooks/init/environment-selector.ts
+++ b/src/hooks/init/environment-selector.ts
@@ -62,13 +62,10 @@ const environmentSelectorHook: Hook<'init'> = async function ({id, argv}) {
       environment = argv[indexOfEnv + 1]
       argv.splice(indexOfEnv, 2)
 
-      if (environment === 'mainnet') {
-        this.log(color.yellow('WARNING: Mainnet is not yet supported.'))
-        // eslint-disable-next-line no-process-exit, unicorn/no-process-exit
-        return process.exit(0)
-      }
+      validateDisabledCommandsOnMainnet(environment, id, argv)
     }
 
+    // If environment is not set, warn the user and exit
     if (environment === undefined) {
       this.log(
         color.yellow(
@@ -79,8 +76,7 @@ const environmentSelectorHook: Hook<'init'> = async function ({id, argv}) {
       return process.exit(0)
     }
 
-    validateDisabledCommandsOnMainnet(environment, id, argv)
-
+    // Otherwise, set the environment
     if ((Object.values(Environment) as string[]).includes(environment)) {
       process.env.HOLOGRAPH_ENVIRONMENT = environment
     }

--- a/src/hooks/init/environment-selector.ts
+++ b/src/hooks/init/environment-selector.ts
@@ -61,9 +61,15 @@ const environmentSelectorHook: Hook<'init'> = async function ({id, argv}) {
     } else if (indexOfEnv !== -1) {
       environment = argv[indexOfEnv + 1]
       argv.splice(indexOfEnv, 2)
+
+      if (environment === 'mainnet') {
+        this.log(color.yellow('WARNING: Mainnet is not yet supported.'))
+        // eslint-disable-next-line no-process-exit, unicorn/no-process-exit
+        return process.exit(0)
+      }
     }
 
-    if (environment === undefined || environment === '') {
+    if (environment === undefined) {
       this.log(
         color.yellow(
           'WARNING: Environment not identified. Set HOLOGRAPH_ENVIRONMENT to develop, testnet, or mainnet in your .env file or set it via the --env flag',

--- a/src/hooks/init/environment-selector.ts
+++ b/src/hooks/init/environment-selector.ts
@@ -67,11 +67,7 @@ const environmentSelectorHook: Hook<'init'> = async function ({id, argv}) {
 
     // If environment is not set, warn the user and exit
     if (environment === undefined) {
-      this.log(
-        color.yellow(
-          'WARNING: Environment not identified. Set HOLOGRAPH_ENVIRONMENT to develop, testnet, or mainnet in your .env file or set it via the --env flag',
-        ),
-      )
+      this.log(color.yellow('WARNING: Environment not identified. Set it via the --env flag'))
       // eslint-disable-next-line no-process-exit, unicorn/no-process-exit
       return process.exit(0)
     }


### PR DESCRIPTION
## Describe Changes

1. If HOLOGRAPH_ENVIORNMENT exists, use that env regardless of the  --env flag
2. If HOLOGRAPH_ENVIRONMENT does not exist, then use the --env flag.
3. If neither is provided, then throw an error saying the --env flag must be provided.

The last comment:
> if --env mainnet is provided and HOLOGRAPH_ADDRESS is empty, then exit with an error saying mainnet support is not available yet

doesn't make sense to me because we have mainnet set in the HOLOGRAPH_ADDRESSES so please clarify if you meant something else @sogoiii or I'm misunderstanding something.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
