### PR TITLE
Fix issue with --env not being a supported flag

### DIFF
--- a/src/hooks/init/environment-selector.ts
+++ b/src/hooks/init/environment-selector.ts
@@ -56,13 +56,15 @@ const environmentSelectorHook: Hook<'init'> = async function ({id, argv}) {
     const indexOfEnv = argv.indexOf('--env')
 
     let environment
+    if (indexOfEnv !== -1) {
+      environment = argv[indexOfEnv + 1]
+      argv.splice(indexOfEnv, 2) // remove --env and the value from args
+      validateDisabledCommandsOnMainnet(environment, id, argv)
+    }
+
+    // If HOLOGRAPH_ENVIRONMENT is set, use or prefer it
     if (env !== undefined) {
       environment = env
-    } else if (indexOfEnv !== -1) {
-      environment = argv[indexOfEnv + 1]
-      argv.splice(indexOfEnv, 2)
-
-      validateDisabledCommandsOnMainnet(environment, id, argv)
     }
 
     // If environment is not set, warn the user and exit


### PR DESCRIPTION
## Describe Changes

- Make it possible for the hook to work when both --env and HOLOGRAPH_ENVIRONMENT are provided

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
