### PR TITLE
Fixed the operator resource amount for dev

### DIFF
--- a/.github/workflows/cicd_develop_staging.yaml
+++ b/.github/workflows/cicd_develop_staging.yaml
@@ -569,9 +569,9 @@ jobs:
             --set resources.avalanche.requests.memory=500Mi \
             \
             --set resources.binance.limits.cpu=500m \
-            --set resources.binance.limits.memory=500Mi \
+            --set resources.binance.limits.memory=520Mi \
             --set resources.binance.requests.cpu=500m \
-            --set resources.binance.requests.memory=520Mi \
+            --set resources.binance.requests.memory=500Mi \
             \
             --set datadog_tags.env=${{ env.CLUSTER_NAME }} \
             --set datadog_tags.service=$RELEASE_NAME \


### PR DESCRIPTION
## Describe Changes

I made this better by doing ...

- The memory limit was lower than the request so the helm deployment was failing [https://github.com/holographxyz/holograph-cli/actions/runs/5048821169]

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [ ] I have checked eslint
