### PR TITLE
Added the ENABLE_PROCESS_BLOCK_RANGE var to be included in all the deployments

### DIFF
--- a/.github/workflows/cicd_develop_staging.yaml
+++ b/.github/workflows/cicd_develop_staging.yaml
@@ -37,10 +37,10 @@ env:
   STG_COMMON_NAMESPACE: develop
   #
   #######################################
-  STG_HOLOGRAPH_INDEXER_HELM_CHART_VERSION: 0.0.97
+  STG_HOLOGRAPH_INDEXER_HELM_CHART_VERSION: 0.0.98
   INDEXER_RELEASE_NAME: indexer-dev # format -> [release_name]-indexer-[env]
   #
-  STG_HOLOGRAPH_OPERATOR_HELM_CHART_VERSION: 0.0.70
+  STG_HOLOGRAPH_OPERATOR_HELM_CHART_VERSION: 0.0.71
   OPERATOR_RELEASE_NAME: operator-dev # format -> [release_name]-operator-[env]
   #######################################
   #
@@ -173,7 +173,7 @@ jobs:
           MODE: 'auto'
           ENABLE_UNSAFE: 'false'
           ENABLE_SYNC: 'true'
-          ENABLE_PROCESS_BLOCK_RANGE: 'undefined' # undefined/true
+          ENABLE_PROCESS_BLOCK_RANGE_arbitrum: 'true' # undefined/true
           UPDATE_BLOCK_HEIGHT: 'api' # api/file/disable
           #
           AVALANCHE_NETWORK: 'fuji'
@@ -211,7 +211,7 @@ jobs:
             \
             --set ENABLE_UNSAFE="${ENABLE_UNSAFE}" \
             --set UPDATE_BLOCK_HEIGHT=$UPDATE_BLOCK_HEIGHT \
-            --set ENABLE_PROCESS_BLOCK_RANGE=$ENABLE_PROCESS_BLOCK_RANGE \
+            --set ENABLE_PROCESS_BLOCK_RANGE.arbitrum=$ENABLE_PROCESS_BLOCK_RANGE_arbitrum \
             \
             --set dev_rpc_config_values.avalancheTestnet_rpc_url=${{ env.indexer_dev_avalancheTestnet_rpc_url }} \
             --set dev_rpc_config_values.polygonTestnet_rpc_url=${{ env.indexer_dev_polygonTestnet_rpc_url }} \
@@ -295,7 +295,7 @@ jobs:
           HEALTHCHECK: 'true'
           MODE: 'auto'
           ENABLE_UNSAFE: 'false'
-          ENABLE_PROCESS_BLOCK_RANGE: 'undefined' # undefined/true
+          ENABLE_PROCESS_BLOCK_RANGE_arbitrum: 'true' # undefined/true
           UPDATE_BLOCK_HEIGHT: 'api' # api/file/disable
           #
           AVALANCHE_NETWORK: 'fuji'
@@ -325,7 +325,7 @@ jobs:
             --set MODE=$MODE \
             --set ENABLE_UNSAFE="${ENABLE_UNSAFE}" \
             --set UPDATE_BLOCK_HEIGHT=$UPDATE_BLOCK_HEIGHT \
-            --set ENABLE_PROCESS_BLOCK_RANGE=$ENABLE_PROCESS_BLOCK_RANGE \
+            --set ENABLE_PROCESS_BLOCK_RANGE.arbitrum=$ENABLE_PROCESS_BLOCK_RANGE_arbitrum \
             \
             --set AVALANCHE_NETWORK=$AVALANCHE_NETWORK \
             --set POLYGON_NETWORK=$POLYGON_NETWORK \


### PR DESCRIPTION
## Describe Changes

I made this better by doing ...

- With the new helm charts the ENABLE_PROCESS_BLOCK_RANGE is set per network/deployment. By default is set to 'undefined' , so I just set it for arbitrum to `true` in the cicd via ENABLE_PROCESS_BLOCK_RANGE_arbitrum

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
