### PR TITLE
feature/HOLO-1019-add-config-file-flag-to-recover-command

### DIFF
--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -302,7 +302,11 @@ export default class Config extends Command {
     if (jsonString !== undefined) {
       this.log(`checking jsonString input`)
       const output = JSON.parse(jsonString)
-      await validateBeta3Schema(output)
+      const result = validateBeta3Schema(output)
+      if (result.error) {
+        throw new Error(`Configuration Validation Check: ${result.error.message}`)
+      }
+
       this.log(output)
       // Since the json at the desired path is valid, we save it!
       await fs.outputJSON(configPath, output, {spaces: 2})

--- a/src/commands/operator/recover.ts
+++ b/src/commands/operator/recover.ts
@@ -65,6 +65,11 @@ export default class Recover extends OperatorJobAwareCommand {
       dependsOn: ['host'],
     }),
     ...HealthCheck.flags,
+    'config-file': Flags.string({description: 'Path to the config file to load'}),
+    // NOTE: Apply dash case to operator and indexer
+    'unsafe-password': Flags.string({
+      description: 'Enter the plain text password for the wallet in the holograph cli config',
+    }),
   }
 
   // API Params
@@ -80,12 +85,13 @@ export default class Recover extends OperatorJobAwareCommand {
    * Command Entry Point
    */
   async run(): Promise<void> {
-    this.log('Loading user configurations...')
-
-    const {userWallet, configFile} = await ensureConfigFileIsValid(this.config.configDir, undefined, true)
-    this.log('User configurations loaded.')
-
     const {flags} = await this.parse(Recover)
+    const configFilePath = flags['config-file'] ?? this.config.configDir
+    const unsafePassword = flags['unsafe-password']
+
+    this.log('Loading user configurations...')
+    const {userWallet, configFile} = await ensureConfigFileIsValid(configFilePath, unsafePassword, true)
+    this.log('User configurations loaded.')
 
     this.operatorMode =
       OperatorMode[

--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -90,6 +90,26 @@ export function decodeLzPacketEvent(
     }
   }
 
+  // This is a fallback for the legacy messaging module address that was updated for all networks except for optimism
+  const toFind2 = '0x803305930C1bbae396D03F496a7bF53Ad7fd4303'.toLowerCase().slice(2, 42)
+  if ('logs' in receipt && receipt.logs !== null && receipt.logs.length > 0) {
+    for (let i = 0, l = receipt.logs.length; i < l; i++) {
+      const log = receipt.logs[i]
+      if (
+        log.topics[0] === targetEvents.LzPacket &&
+        (target === undefined || (target !== undefined && log.address.toLowerCase() === target))
+      ) {
+        const packetPayload = iface.decodeEventLog(lzPacketEventFragment, log.data, log.topics)[0] as string
+        if (packetPayload.indexOf(toFind2) > 0) {
+          let index: number = packetPayload.indexOf(toFind2)
+          // address + bytes2 + address
+          index += 40 + 4 + 40
+          return ('0x' + packetPayload.slice(Math.max(0, index))).toLowerCase()
+        }
+      }
+    }
+  }
+
   return undefined
 }
 


### PR DESCRIPTION
## Describe Changes

I made this better by doing ...

- Add `config-file` flag to the recover command.
- Add`unsafe-password` flags to the recover command.
- Applied OLD LZ address to decode function

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] Code styles have been enforced
- [ ] I have checked eslint
