### PR TITLE
HOLO-1022: Clean up statically defined and unused variables

### DIFF
--- a/src/commands/analyze/index.ts
+++ b/src/commands/analyze/index.ts
@@ -15,7 +15,7 @@ import {
 } from '@holographxyz/networks'
 
 import {ensureConfigFileIsValid} from '../../utils/config'
-import {toAscii, sha3, storageSlot} from '../../utils/utils'
+import {toAscii, sha3, storageSlot} from '../../utils/web3'
 import {FilterType, BlockJob, NetworkMonitor, TransactionType} from '../../utils/network-monitor'
 import ApiService from '../../services/api-service'
 import {CrossChainTransaction, TransactionStatus, Logger} from '../../types/api'

--- a/src/commands/bridge/contract.ts
+++ b/src/commands/bridge/contract.ts
@@ -9,7 +9,7 @@ import {TransactionReceipt} from '@ethersproject/abstract-provider'
 import {networks, supportedShortNetworks} from '@holographxyz/networks'
 
 import {ensureConfigFileIsValid} from '../../utils/config'
-import {web3, zeroAddress} from '../../utils/utils'
+import {web3, zeroAddress} from '../../utils/web3'
 import {NetworkMonitor} from '../../utils/network-monitor'
 import {DeploymentConfig} from '../../utils/contract-deployment'
 import {validateNetwork, validateNonEmptyString, checkOptionFlag, checkStringFlag} from '../../utils/validation'

--- a/src/commands/bridge/nft.ts
+++ b/src/commands/bridge/nft.ts
@@ -225,7 +225,7 @@ export default class BridgeNFT extends Command {
     gasPrice = gasPrice.add(gasPrice.div(BigNumber.from('2')))
 
     // override gas price to minimum if set
-    gasPrice = overrideToMinGasPrice(networks[destinationNetwork].chain as SupportedChainIds, gasPrice)
+    gasPrice = overrideToMinGasPrice(networks[destinationNetwork].chain, gasPrice)
 
     payload = await this.networkMonitor.bridgeContract
       .connect(this.networkMonitor.providers[sourceNetwork])

--- a/src/commands/create/contract.ts
+++ b/src/commands/create/contract.ts
@@ -8,7 +8,7 @@ import {networks} from '@holographxyz/networks'
 
 import {BytecodeType, bytecodes} from '../../utils/bytecodes'
 import {ensureConfigFileIsValid} from '../../utils/config'
-import {web3, zeroAddress, remove0x, sha3, dropEventsEnabled} from '../../utils/utils'
+import {web3, zeroAddress, remove0x, sha3, dropEventsEnabled} from '../../utils/web3'
 import {NetworkMonitor} from '../../utils/network-monitor'
 import {
   ContractDeployment,

--- a/src/commands/create/nft.ts
+++ b/src/commands/create/nft.ts
@@ -123,7 +123,7 @@ export default class NFT extends Command {
     )
 
     // Load the ABI for the collection type to mint from
-    let collectionABI: string
+    let collectionABI: Record<string, any>[]
     switch (collectionType) {
       case 'CxipERC721':
         collectionABI = abis.CxipERC721ABI

--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -29,7 +29,7 @@ import {
 } from '../../utils/event'
 
 import {BlockJob, NetworkMonitor, networksFlag, replayFlag, processBlockRange} from '../../utils/network-monitor'
-import {zeroAddress} from '../../utils/utils'
+import {zeroAddress} from '../../utils/web3'
 import {HealthCheck} from '../../base-commands/healthcheck'
 import {ensureConfigFileIsValid} from '../../utils/config'
 import ApiService from '../../services/api-service'

--- a/src/commands/operator/bond.ts
+++ b/src/commands/operator/bond.ts
@@ -13,7 +13,7 @@ import TokenChainService from '../../services/token-chain-service'
 import {PodBondAmounts} from '../../types/holograph-operator'
 import {ensureConfigFileIsValid} from '../../utils/config'
 import {NetworkMonitor, networkFlag} from '../../utils/network-monitor'
-import {toLong18} from '../../utils/utils'
+import {toLong18} from '../../utils/web3'
 import {checkOptionFlag} from '../../utils/validation'
 import Operator from '.'
 

--- a/src/commands/operator/recover.ts
+++ b/src/commands/operator/recover.ts
@@ -8,7 +8,6 @@ import {networks, supportedNetworks} from '@holographxyz/networks'
 
 import {ensureConfigFileIsValid} from '../../utils/config'
 import {NetworkMonitor, OperatorMode} from '../../utils/network-monitor'
-import {chainIdToNetwork, networkToChainId, sha3} from '../../utils/utils'
 import {checkOptionFlag, checkTransactionHashFlag} from '../../utils/validation'
 import {OperatorJobAwareCommand} from '../../utils/operator-job'
 import {HealthCheck} from '../../base-commands/healthcheck'
@@ -18,6 +17,7 @@ import {CrossChainTransaction, Logger, TransactionStatus} from '../../types/api'
 import color from '@oclif/color'
 import {decodeAvailableOperatorJobEvent, decodeLzPacketEvent} from '../../events/events'
 import * as fs from 'fs-extra'
+import {chainIdToNetwork, networkToChainId, sha3} from '../../utils/web3'
 
 enum Step {
   OPERATOR,

--- a/src/commands/status/contract.ts
+++ b/src/commands/status/contract.ts
@@ -7,6 +7,8 @@ import {ensureConfigFileIsValid} from '../../utils/config'
 import {addressValidator} from '../../utils/validation'
 import {networks} from '@holographxyz/networks'
 import {NetworkMonitor} from '../../utils/network-monitor'
+import {getABIs} from '../../utils/contracts'
+import {getEnvironment} from '@holographxyz/environment'
 
 export default class Contract extends Command {
   static LAST_BLOCKS_FILE_NAME = 'blocks.json'

--- a/src/handlers/sqs-indexer/handle-available-operator-job-event.ts
+++ b/src/handlers/sqs-indexer/handle-available-operator-job-event.ts
@@ -3,7 +3,7 @@ import {TransactionResponse} from '@ethersproject/abstract-provider'
 import {NetworkMonitor} from '../../utils/network-monitor'
 
 import SqsService from '../../services/sqs-service'
-import {networkToChainId} from '../../utils/utils'
+import {networkToChainId} from '../../utils/web3'
 import {EventName, PayloadType, SqsMessageBody} from '../../types/sqs'
 
 async function handleAvailableOperatorJobEvent(

--- a/src/handlers/sqs-indexer/handle-bridge-event.ts
+++ b/src/handlers/sqs-indexer/handle-bridge-event.ts
@@ -1,7 +1,7 @@
 import {TransactionResponse} from '@ethersproject/abstract-provider'
 
 import SqsService from '../../services/sqs-service'
-import {networkToChainId} from '../../utils/utils'
+import {networkToChainId} from '../../utils/web3'
 import {NetworkMonitor} from '../../utils/network-monitor'
 import {EventName, PayloadType, SqsMessageBody} from '../../types/sqs'
 

--- a/src/handlers/sqs-indexer/handle-contract-deployed-event.ts
+++ b/src/handlers/sqs-indexer/handle-contract-deployed-event.ts
@@ -1,7 +1,7 @@
 import {TransactionResponse} from '@ethersproject/abstract-provider'
 import {NetworkMonitor} from '../../utils/network-monitor'
 import SqsService from '../../services/sqs-service'
-import {networkToChainId} from '../../utils/utils'
+import {networkToChainId} from '../../utils/web3'
 import {EventName, PayloadType, SqsMessageBody} from '../../types/sqs'
 
 async function handleContractDeployedEvent(

--- a/src/handlers/sqs-indexer/handle-transfer-erc721-event.ts
+++ b/src/handlers/sqs-indexer/handle-transfer-erc721-event.ts
@@ -1,7 +1,7 @@
 import {TransactionResponse} from '@ethersproject/abstract-provider'
 import {NetworkMonitor} from '../../utils/network-monitor'
 import SqsService from '../../services/sqs-service'
-import {networkToChainId, remove0x} from '../../utils/utils'
+import {networkToChainId, remove0x} from '../../utils/web3'
 import {EventName, PayloadType, SqsMessageBody} from '../../types/sqs'
 import {TransferERC721Event} from '../../utils/event'
 

--- a/src/scripts/create-drop.ts
+++ b/src/scripts/create-drop.ts
@@ -1,5 +1,3 @@
-import * as fs from 'fs-extra'
-import * as path from 'node:path'
 import {Contract, ethers} from 'ethers'
 import {SalesConfiguration} from '../types/drops'
 import {bytecodes} from '../utils/bytecodes'
@@ -8,7 +6,7 @@ import {
   generateHolographERC721InitCode,
   generateMetadataRendererInitCode,
 } from '../utils/initcode'
-import {dropEventsEnabled, sha3, web3} from '../utils/utils'
+import {dropEventsEnabled, sha3, web3} from '../utils/web3'
 import {networks} from '@holographxyz/networks'
 import {strictECDSA, Signature} from '../utils/signature'
 import {DeploymentConfig} from '../utils/contract-deployment'
@@ -35,9 +33,7 @@ require('dotenv').config()
 
   // Get the ABI
   const abis = await getABIs(ENVIRONMENT)
-
-  const holographABI = await fs.readJson(path.join(__dirname, `../abi/${ENVIRONMENT}/Holograph.json`))
-  const holograph = new Contract(HOLOGRAPH_ADDRESSES[ENVIRONMENT], holographABI, provider)
+  const holograph = new Contract(HOLOGRAPH_ADDRESSES[ENVIRONMENT], abis.HolographABI, provider)
   const factoryProxyAddress = (await holograph.getFactory()).toLowerCase()
 
   // NOTE: Since the Drop contract is an extension of the HolographERC721 enforcer, the contract type must be updated accordingly

--- a/src/services/faucet-service.ts
+++ b/src/services/faucet-service.ts
@@ -2,7 +2,8 @@ import {Contract} from '@ethersproject/contracts'
 import {TransactionReceipt} from '@ethersproject/providers'
 import {BigNumber} from '@ethersproject/bignumber'
 
-import {getSecondsLeft, toShort18, toShort18Str} from '../utils/utils'
+import {getSecondsLeft} from '../utils/utils'
+import {toShort18, toShort18Str} from '../utils/web3'
 import CoreChainService from './core-chain-service'
 import {NetworkMonitor} from '../utils/network-monitor'
 

--- a/src/utils/contract-deployment.ts
+++ b/src/utils/contract-deployment.ts
@@ -5,7 +5,7 @@ import {BigNumber, BigNumberish, BytesLike} from 'ethers'
 import Web3 from 'web3'
 
 import {bytecodes, BytecodeType} from './bytecodes'
-import {remove0x, sha3} from './utils'
+import {remove0x, sha3} from './web3'
 import {validateNetwork, validateNonEmptyString, validateTransactionHash} from './validation'
 
 export const web3 = new Web3()

--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -19,6 +19,7 @@ interface ContractAbis {
   LayerZeroABI: Array<Record<string, any>>
   MockLZEndpointABI: Array<Record<string, any>>
   EditionsMetadataRendererABI: Array<Record<string, any>>
+  OwnerABI: Array<Record<string, any>>
 }
 
 export const getABIs = async (environment: string): Promise<ContractAbis> => {
@@ -40,6 +41,7 @@ export const getABIs = async (environment: string): Promise<ContractAbis> => {
     EditionsMetadataRendererABI: await fs.readJson(
       path.join(__dirname, `../abi/${environment}/EditionsMetadataRenderer.json`),
     ),
+    OwnerABI: await fs.readJson(path.join(__dirname, `../abi/${environment}/Owner.json`)),
   }
 }
 

--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -3,7 +3,25 @@ const path = require('node:path')
 
 import {Environment} from '@holographxyz/environment'
 
-export const getABIs = async (environment: string): Promise<any> => {
+interface ContractAbis {
+  CxipERC721ABI: Array<Record<string, any>>
+  FaucetABI: Array<Record<string, any>>
+  HolographABI: Array<Record<string, any>>
+  HolographerABI: Array<Record<string, any>>
+  HolographBridgeABI: Array<Record<string, any>>
+  HolographERC20ABI: Array<Record<string, any>>
+  HolographERC721ABI: Array<Record<string, any>>
+  HolographDropERC721ABI: Array<Record<string, any>>
+  HolographFactoryABI: Array<Record<string, any>>
+  HolographInterfacesABI: Array<Record<string, any>>
+  HolographOperatorABI: Array<Record<string, any>>
+  HolographRegistryABI: Array<Record<string, any>>
+  LayerZeroABI: Array<Record<string, any>>
+  MockLZEndpointABI: Array<Record<string, any>>
+  EditionsMetadataRendererABI: Array<Record<string, any>>
+}
+
+export const getABIs = async (environment: string): Promise<ContractAbis> => {
   return {
     CxipERC721ABI: await fs.readJson(path.join(__dirname, `../abi/${environment}/CxipERC721.json`)),
     FaucetABI: await fs.readJson(path.join(__dirname, `../abi/${environment}/Faucet.json`)),
@@ -18,6 +36,7 @@ export const getABIs = async (environment: string): Promise<any> => {
     HolographOperatorABI: await fs.readJson(path.join(__dirname, `../abi/${environment}/HolographOperator.json`)),
     HolographRegistryABI: await fs.readJson(path.join(__dirname, `../abi/${environment}/HolographRegistry.json`)),
     LayerZeroABI: await fs.readJson(path.join(__dirname, `../abi/${environment}/LayerZeroEndpointInterface.json`)),
+    MockLZEndpointABI: await fs.readJson(path.join(__dirname, `../abi/${environment}/MockLZEndpoint.json`)),
     EditionsMetadataRendererABI: await fs.readJson(
       path.join(__dirname, `../abi/${environment}/EditionsMetadataRenderer.json`),
     ),

--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -2,6 +2,26 @@ import * as fs from 'fs-extra'
 const path = require('node:path')
 
 import {Environment} from '@holographxyz/environment'
+import {Contract} from 'ethers'
+
+export type ContractInfo = {
+  address: string
+  abi: any
+}
+
+export type ContractMap = {
+  [contractName: string]: ContractInfo
+}
+
+export interface IContracts {
+  cxipERC721Contract: Contract
+  bridgeContract: Contract
+  factoryContract: Contract
+  interfacesContract: Contract
+  operatorContract: Contract
+  registryContract: Contract
+  messagingModuleContract: Contract
+}
 
 interface ContractAbis {
   CxipERC721ABI: Array<Record<string, any>>

--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -43,7 +43,7 @@ import {
 import {ConfigFile, ConfigNetwork, ConfigNetworks} from './config'
 import {GasPricing, initializeGasPricing, updateGasPricing} from './gas'
 import {capitalize, sleep} from './utils'
-import {CXIP_ERC721_ADDRESSES, HOLOGRAPH_ADDRESSES, getABIs} from './contracts'
+import {CXIP_ERC721_ADDRESSES, ContractMap, HOLOGRAPH_ADDRESSES, IContracts, getABIs} from './contracts'
 import {BlockHeight, BlockHeightProcessType} from '../types/api'
 import ApiService from '../services/api-service'
 import {iface, packetEventFragment, targetEvents} from '../events/events'
@@ -139,25 +139,6 @@ export type TransactionFilter = {
   type: FilterType
   match: string | {[key: string]: string}
   networkDependant: boolean
-}
-
-export type ContractInfo = {
-  address: string
-  abi: any
-}
-
-export type ContractMap = {
-  [contractName: string]: ContractInfo
-}
-
-interface IContracts {
-  cxipERC721Contract: Contract
-  bridgeContract: Contract
-  factoryContract: Contract
-  interfacesContract: Contract
-  operatorContract: Contract
-  registryContract: Contract
-  messagingModuleContract: Contract
 }
 
 const TIMEOUT_THRESHOLD = 60_000

--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -42,7 +42,7 @@ import {
 
 import {ConfigFile, ConfigNetwork, ConfigNetworks} from './config'
 import {GasPricing, initializeGasPricing, updateGasPricing} from './gas'
-import {capitalize, NETWORK_COLORS, sleep, zeroAddress} from './utils'
+import {capitalize, sleep} from './utils'
 import {CXIP_ERC721_ADDRESSES, HOLOGRAPH_ADDRESSES} from './contracts'
 import {BlockHeight, BlockHeightProcessType} from '../types/api'
 import ApiService from '../services/api-service'
@@ -59,6 +59,7 @@ import {
   InterestingTransaction,
 } from '../types/network-monitor'
 import {BlockHeightOptions} from '../flags/update-block-height.flag'
+import {NETWORK_COLORS, zeroAddress} from './web3'
 
 export const replayFlag = {
   replay: Flags.string({

--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -762,7 +762,7 @@ export class NetworkMonitor {
       messagingModuleContract: {address: this.messagingModuleAddress, abi: abis.LayerZeroABI},
     }
 
-    for (const contractName in contractsMap) {
+    for (const contractName of Object.keys(contractsMap)) {
       this.contracts[contractName as keyof IContracts] = new Contract(
         contractsMap[contractName].address,
         contractsMap[contractName].abi,

--- a/src/utils/network-monitor.ts
+++ b/src/utils/network-monitor.ts
@@ -763,7 +763,7 @@ export class NetworkMonitor {
     }
 
     for (const contractName of Object.keys(contractsMap)) {
-      this.contracts[contractName as keyof IContracts] = new Contract(
+      ;(this[contractName as keyof this] as Contract) = new Contract(
         contractsMap[contractName].address,
         contractsMap[contractName].abi,
         this.providers[this.networks[0]],

--- a/src/utils/operator-job.ts
+++ b/src/utils/operator-job.ts
@@ -3,7 +3,7 @@ import {Contract} from '@ethersproject/contracts'
 import {formatUnits} from '@ethersproject/units'
 
 import {NetworkMonitor} from './network-monitor'
-import {zeroAddress} from './utils'
+import {zeroAddress} from './web3'
 import {HealthCheck} from '../base-commands/healthcheck'
 
 export interface OperatorJobDetails {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,11 +1,3 @@
-import Web3 from 'web3'
-
-import {BigNumber, BigNumberish} from '@ethersproject/bignumber'
-import {formatUnits} from '@ethersproject/units'
-import {networks} from '@holographxyz/networks'
-
-export const web3 = new Web3()
-
 export function randomNumber(min: number, max: number): number {
   return Math.floor(Math.random() * (max - min)) + min
 }
@@ -39,79 +31,9 @@ export const webSocketConfig = {
   },
 }
 
-export const networkToChainId: Record<string, number> = Object.fromEntries(
-  Object.entries(networks).map(([key, network]) => [key, network.chain]),
-)
-
-// NOTE: This is an inverse map of networkToChainId
-export const chainIdToNetwork = (): Record<number, string> => {
-  const flipped = Object.entries(networkToChainId).map(([key, value]) => [value, key])
-  return Object.fromEntries(flipped)
-}
-
-export const NETWORK_COLORS: Record<string, string> = Object.fromEntries(
-  Object.entries(networks).map(([key, network]) => [key, network.color]),
-)
-
 export const rgbToHex = (rgb: number): string => {
   const hex = Number(rgb).toString(16)
   return hex.length === 1 ? `0${hex}` : hex
-}
-
-export const zeroAddress: string = '0x' + '00'.repeat(20)
-
-export function allEventsEnabled(): string {
-  return '0x' + 'ff'.repeat(32)
-}
-
-export function dropEventsEnabled(): string {
-  return '0x0000000000000000000000000000000000000000000000000000000000065000'
-}
-
-export function remove0x(input: string): string {
-  if (input.startsWith('0x')) {
-    return input.slice(2)
-  }
-
-  return input
-}
-
-export function toAscii(input: string): string {
-  input = remove0x(input.trim().toLowerCase())
-  if (input.length % 2 !== 0) {
-    input = '0' + input
-  }
-
-  const arr = [...input]
-  let output = ''
-  for (let i = 0, l = input.length; i < l; i += 2) {
-    const chunk = arr[i] + arr[i + 1]
-    if (chunk !== '00') {
-      output += String.fromCharCode(Number.parseInt(chunk, 16))
-    }
-  }
-
-  return output
-}
-
-export function sha3(input: string | undefined): string {
-  // handle empty bytes issue
-  if (input === undefined || input === '' || input === '0x') {
-    return '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
-  }
-
-  return web3.utils.keccak256(input)
-}
-
-export function functionSignature(input: string | undefined): string {
-  return sha3(input).slice(0, 10)
-}
-
-export function storageSlot(input: string): string {
-  return (
-    '0x' +
-    remove0x(web3.utils.toHex(web3.utils.toBN(web3.utils.keccak256(input)).sub(web3.utils.toBN(1)))).padStart(64, '0')
-  )
 }
 
 export function randomASCII(bytes: number): string {
@@ -131,22 +53,6 @@ export function isStringAValidURL(s: string): boolean {
   } catch {
     return false
   }
-}
-
-export const toShort18Str = (num: string): string => {
-  return formatUnits(num, 'ether')
-}
-
-export const toShort18 = (num: BigNumberish): BigNumber => {
-  return BigNumber.from(num).div(BigNumber.from('10').pow(18))
-}
-
-export const toLong18 = (num: BigNumberish): BigNumber => {
-  return BigNumber.from(num).mul(BigNumber.from('10').pow(18))
-}
-
-export const generateRandomSalt = (): string => {
-  return '0x' + Date.now().toString(16).padStart(64, '0')
 }
 
 export const utf8ToBytes32 = (str: string): string => {
@@ -198,13 +104,6 @@ export async function retry<T = any>(
     // eslint-disable-next-line no-process-exit, unicorn/no-process-exit
     process.exit()
   }
-}
-
-export function generateHashedName(name: string): string {
-  // eslint-disable-next-line unicorn/prefer-string-slice
-  const asciiHex = web3.utils.asciiToHex(name).substring(2) // remove '0x' prefix
-  const paddedHex = asciiHex.padStart(64, '0')
-  return `0x${paddedHex}`
 }
 
 export function safeStringify(obj: any, indent = 2): string {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -7,7 +7,7 @@ import {BytecodeType} from './bytecodes'
 import {ConfigNetworks} from './config'
 import {DeploymentType, deploymentProcesses} from './contract-deployment'
 import {TokenUriType} from './asset-deployment'
-import {remove0x} from './utils'
+import {remove0x} from './web3'
 
 export interface SelectOption {
   name: string

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -1,133 +1,27 @@
-import {BigNumber} from 'ethers'
+import {Network, networks} from '@holographxyz/networks'
+import Web3 from 'web3'
+
+import {BigNumber, BigNumberish} from '@ethersproject/bignumber'
+import {formatUnits} from '@ethersproject/units'
+
+export const web3 = new Web3()
 
 const HOLOGRAPH_ENVIRONMENT = process.env.HOLONET_ENVIRONMENT || 'develop'
 export const IS_MAINNET = HOLOGRAPH_ENVIRONMENT === 'mainnet'
-export const DISCONNECT_ACTION = 'disconnect_action'
 
-export const CHAIN_IDS = {
-  ethereum: 1,
-  goerli: 5,
-  polygon: 137,
-  mumbai: 80_001,
-  bsc: 56,
-  testbsc: 97,
-  avalanche: 43_114,
-  fuji: 43_113,
-  fantom: 250,
-  optimism: 10,
-  optimismGoerli: 420,
-  [DISCONNECT_ACTION]: 0,
-} as const
+export const networkToChainId: Readonly<Record<string, number>> = Object.fromEntries(
+  Object.entries(networks).map(([key, network]) => [key, network.chain]),
+)
 
-export const ABI_ENVIRONMENT_VALUES = {
-  develop: 'develop',
-  testnet: 'testnet',
-  mainnet: 'mainnet',
-} as const
-
-const C = CHAIN_IDS
-
-export const CHAIN_NAMES = {
-  [C.ethereum]: 'ethereum',
-  [C.goerli]: 'goerli',
-  [C.polygon]: 'polygon',
-  [C.mumbai]: 'mumbai',
-  [C.bsc]: 'bsc',
-  [C.testbsc]: 'testbsc',
-  [C.avalanche]: 'avalanche',
-  [C.fantom]: 'fantom',
-  [C.fuji]: 'fuji',
-  [C.optimism]: 'optimism',
-  [C.optimismGoerli]: 'optimismGoerli',
-  [C[DISCONNECT_ACTION]]: DISCONNECT_ACTION,
-} as const
-
-// TODO: Improve naming of this variable/refactor soon
-export const CHAIN_FULL_NAMES = {
-  [C.ethereum]: 'Ethereum',
-  [C.goerli]: 'Goerli',
-  [C.polygon]: 'Polygon',
-  [C.mumbai]: 'Mumbai',
-  [C.bsc]: 'BNB Chain',
-  [C.testbsc]: 'BNB Chain',
-  [C.avalanche]: 'Avalanche',
-  [C.fantom]: 'Fantom',
-  [C.fuji]: 'Fuji',
-  [C.optimism]: 'Optimism',
-  [C.optimismGoerli]: 'Optimism',
-  [C[DISCONNECT_ACTION]]: DISCONNECT_ACTION,
+// NOTE: This is an inverse map of networkToChainId
+export const chainIdToNetwork = (): Readonly<Record<number, string>> => {
+  const flipped = Object.entries(networkToChainId).map(([key, value]) => [value, key])
+  return Object.fromEntries(flipped)
 }
 
-export const CHAIN_NAMES_TO_IDS = {
-  [CHAIN_NAMES[C.ethereum]]: C.ethereum,
-  [CHAIN_NAMES[C.goerli]]: C.goerli,
-  [CHAIN_NAMES[C.polygon]]: C.polygon,
-  [CHAIN_NAMES[C.mumbai]]: C.mumbai,
-  [CHAIN_NAMES[C.bsc]]: C.bsc,
-  [CHAIN_NAMES[C.testbsc]]: C.testbsc,
-  [CHAIN_NAMES[C.avalanche]]: C.avalanche,
-  [CHAIN_NAMES[C.fantom]]: C.fantom,
-  [CHAIN_NAMES[C.fuji]]: C.fuji,
-  [CHAIN_NAMES[C.optimism]]: C.optimism,
-  [CHAIN_NAMES[C.optimismGoerli]]: C.optimismGoerli,
-  [CHAIN_NAMES[C[DISCONNECT_ACTION]]]: C[DISCONNECT_ACTION],
-} as const
-
-export const CHAIN_NETWORKS = {
-  [C.ethereum]: 'ethereum',
-  [C.goerli]: 'ethereum',
-  [C.polygon]: 'polygon',
-  [C.mumbai]: 'polygon',
-  [C.bsc]: 'bsc',
-  [C.testbsc]: 'bsc',
-  [C.avalanche]: 'avalanche',
-  [C.fantom]: 'fantom',
-  [C.fuji]: 'avalanche',
-  [C.optimism]: 'optimism',
-  [C.optimismGoerli]: 'optimism',
-} as const
-
-export const OPEN_SEA_NFT_URL_PREFIX = {
-  [C.ethereum]: 'https://opensea.io/assets/ethereum',
-  [C.goerli]: 'https://testnets.opensea.io/assets/goerli',
-  [C.polygon]: 'https://opensea.io/assets/matic',
-  [C.mumbai]: 'https://testnets.opensea.io/assets/mumbai',
-  [C.avalanche]: 'https://opensea.io/assets/avalanche',
-  [C.fuji]: 'https://testnets.opensea.io/assets/avalanche-fuji',
-  [C.bsc]: 'https://opensea.io/assets/bsc',
-  [C.testbsc]: 'https://testnets.opensea.io/assets/bsc-testnet',
-  [C.optimism]: 'https://opensea.io/assets/optimism',
-  [C.optimismGoerli]: 'https://testnets.opensea.io/assets/optimism-goerli',
-} as const
-
-declare global {
-  type ChainIds = keyof typeof CHAIN_NAMES
-  type ChainNames = keyof typeof CHAIN_IDS
-  type SupportedChainIds = (typeof SUPPORTED_CHAIN_IDS)[number]
-  type SupportedMainnetChainIds = (typeof SUPPORTED_MAINNET_CHAIN_IDS)[number]
-  type SupportedTestnetChainIds = (typeof SUPPORTED_TESTNET_CHAIN_IDS)[number]
-  type SupportedChainNames = (typeof SUPPORTED_CHAIN_NAMES)[number]
-  type SupportedNetworkNames = (typeof SUPPORTED_NETWORK_NAMES)[number]
-  type DropdownChainIds = (typeof DROPDOWN_CHAIN_IDS)[number]
-  type DropdownChainNames = (typeof DROPDOWN_CHAIN_NAMES)[number]
-  type DisabledChainIds = (typeof DISABLED_CHAIN_IDS)[number]
-}
-
-export const DEFAULT_CHAIN_ID = IS_MAINNET ? C.ethereum : C.goerli
-export const DEFAULT_CHAIN_NAME = CHAIN_NAMES[DEFAULT_CHAIN_ID]
-export const SUPPORTED_MAINNET_CHAIN_IDS = [C.ethereum, C.polygon, C.avalanche, C.bsc, C.optimism]
-export const SUPPORTED_TESTNET_CHAIN_IDS = [C.goerli, C.mumbai, C.fuji, C.testbsc, C.optimismGoerli]
-
-export const SUPPORTED_CHAIN_IDS: Array<SupportedMainnetChainIds | SupportedTestnetChainIds> = IS_MAINNET
-  ? SUPPORTED_MAINNET_CHAIN_IDS
-  : SUPPORTED_TESTNET_CHAIN_IDS
-export const SUPPORTED_CHAIN_NAMES = SUPPORTED_CHAIN_IDS.map(id => CHAIN_NAMES[id])
-export const SUPPORTED_NETWORK_NAMES = SUPPORTED_CHAIN_IDS.map(id => CHAIN_NETWORKS[id])
-export const DISABLED_CHAIN_IDS = []
-export const DISABLED_CHAIN_NAMES = DISABLED_CHAIN_IDS.map(id => CHAIN_NAMES[id])
-
-export const DROPDOWN_CHAIN_IDS = [...SUPPORTED_CHAIN_IDS, C.disconnect_action]
-export const DROPDOWN_CHAIN_NAMES = DROPDOWN_CHAIN_IDS.map(id => CHAIN_NAMES[id])
+export const NETWORK_COLORS: Readonly<Record<string, string>> = Object.fromEntries(
+  Object.entries(networks).map(([key, network]) => [key, network.color]),
+)
 
 export const DUMMY_WALLET = {
   privateKey: '494cf7d8741e5fea465cc011b86d30e174fc0483a64675c73c92f109d5cee6ee',
@@ -142,23 +36,20 @@ export const formatTokenId = (tokenId: string) => {
   return BigNumber.from(`${tokenId}`).toString()
 }
 
-export const getOpenSeaNftURL = (chainId: SupportedChainIds, contractAddress: string, tokenId: string) =>
-  tokenId ? `${OPEN_SEA_NFT_URL_PREFIX[chainId]}/${contractAddress}/${formatTokenId(tokenId)}` : ''
-
-export const overrideToMinGasPrice = function (chainId: SupportedChainIds, gasPrice: BigNumber) {
+export const overrideToMinGasPrice = function (chainId: Network['chain'], gasPrice: BigNumber) {
   // NOTE: Here only temporarily. This will be replaced by an RPC call to the blockchain.
   const MIN_GAS_PRICE = {
-    [CHAIN_IDS.ethereum]: 40_000_000_001,
-    [CHAIN_IDS.goerli]: 5_000_000_001,
-    [CHAIN_IDS.polygon]: 200_000_000_001,
-    [CHAIN_IDS.bsc]: 3_000_000_001,
-    [CHAIN_IDS.testbsc]: 1_000_000_001,
-    [CHAIN_IDS.avalanche]: 30_000_000_001,
-    [CHAIN_IDS.fantom]: 200_000_000_001,
-    [CHAIN_IDS.mumbai]: 5_000_000_001,
-    [CHAIN_IDS.fuji]: 30_000_000_001,
-    [CHAIN_IDS.optimism]: 10_000_001,
-    [CHAIN_IDS.optimismGoerli]: 5_000_000_001,
+    [networkToChainId.ethereum]: 40_000_000_001,
+    [networkToChainId.goerli]: 5_000_000_001,
+    [networkToChainId.polygon]: 200_000_000_001,
+    [networkToChainId.bsc]: 3_000_000_001,
+    [networkToChainId.testbsc]: 1_000_000_001,
+    [networkToChainId.avalanche]: 30_000_000_001,
+    [networkToChainId.fantom]: 200_000_000_001,
+    [networkToChainId.mumbai]: 5_000_000_001,
+    [networkToChainId.fuji]: 30_000_000_001,
+    [networkToChainId.optimism]: 10_000_001,
+    [networkToChainId.optimismGoerli]: 5_000_000_001,
   } as const
 
   if (BigNumber.from(MIN_GAS_PRICE[chainId]).gt(gasPrice)) {
@@ -166,4 +57,83 @@ export const overrideToMinGasPrice = function (chainId: SupportedChainIds, gasPr
   }
 
   return gasPrice
+}
+
+export const zeroAddress: string = '0x' + '00'.repeat(20)
+
+export function allEventsEnabled(): string {
+  return '0x' + 'ff'.repeat(32)
+}
+
+export function dropEventsEnabled(): string {
+  return '0x0000000000000000000000000000000000000000000000000000000000065000'
+}
+
+export function remove0x(input: string): string {
+  if (input.startsWith('0x')) {
+    return input.slice(2)
+  }
+
+  return input
+}
+
+export function toAscii(input: string): string {
+  input = remove0x(input.trim().toLowerCase())
+  if (input.length % 2 !== 0) {
+    input = '0' + input
+  }
+
+  const arr = [...input]
+  let output = ''
+  for (let i = 0, l = input.length; i < l; i += 2) {
+    const chunk = arr[i] + arr[i + 1]
+    if (chunk !== '00') {
+      output += String.fromCharCode(Number.parseInt(chunk, 16))
+    }
+  }
+
+  return output
+}
+
+export function sha3(input: string | undefined): string {
+  // handle empty bytes issue
+  if (input === undefined || input === '' || input === '0x') {
+    return '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
+  }
+
+  return web3.utils.keccak256(input)
+}
+
+export function functionSignature(input: string | undefined): string {
+  return sha3(input).slice(0, 10)
+}
+
+export function storageSlot(input: string): string {
+  return (
+    '0x' +
+    remove0x(web3.utils.toHex(web3.utils.toBN(web3.utils.keccak256(input)).sub(web3.utils.toBN(1)))).padStart(64, '0')
+  )
+}
+
+export const toShort18Str = (num: string): string => {
+  return formatUnits(num, 'ether')
+}
+
+export const toShort18 = (num: BigNumberish): BigNumber => {
+  return BigNumber.from(num).div(BigNumber.from('10').pow(18))
+}
+
+export const toLong18 = (num: BigNumberish): BigNumber => {
+  return BigNumber.from(num).mul(BigNumber.from('10').pow(18))
+}
+
+export const generateRandomSalt = (): string => {
+  return '0x' + Date.now().toString(16).padStart(64, '0')
+}
+
+export function generateHashedName(name: string): string {
+  // eslint-disable-next-line unicorn/prefer-string-slice
+  const asciiHex = web3.utils.asciiToHex(name).substring(2) // remove '0x' prefix
+  const paddedHex = asciiHex.padStart(64, '0')
+  return `0x${paddedHex}`
 }


### PR DESCRIPTION
## Describe Changes

- Cleanup a lot of unused statically defined variables (we'll eventually be able to import anything we need like this from the SDK as we need it)
- Move web3 specific functions into the web3 file instead of generic utils file
- Use getABIs instead of __dir
- Add more type safety
- Got rid of all uses of `await fs.readJson(path.join(__dirname, `../abi/${environment}/<ContractName>.json`)` except for in the reusable utility function `getABIs`

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
