### PR TITLE
Initial pass at adding logic to capture the type of xchain message

### DIFF
--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -266,7 +266,9 @@ export default class Indexer extends HealthCheck {
 
   detectCrossChainMessageType(allLogs: Log[]): CrossChainMessageType {
     const crossChainMessageTopics = {
+      // BridgeableContractDeployed(address,bytes32)
       [CrossChainMessageType.CONTRACT]: '0xa802207d4c618b40db3b25b7b90e6f483e16b2c1f8d3610b15b345a718c6b41b',
+      // Transfer(address,address,uint256)
       [CrossChainMessageType.ERC721]: '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
     }
 

--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -265,25 +265,21 @@ export default class Indexer extends HealthCheck {
   }
 
   detectCrossChainMessageType(allLogs: Log[]): CrossChainMessageType {
-    const crossChainMessageTopics = {
-      // BridgeableContractDeployed(address,bytes32)
-      [CrossChainMessageType.CONTRACT]: '0xa802207d4c618b40db3b25b7b90e6f483e16b2c1f8d3610b15b345a718c6b41b',
-      // Transfer(address,address,uint256)
-      [CrossChainMessageType.ERC721]: '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+    const foundLog = allLogs.find(
+      log =>
+        log.topics[0] === this.bloomFilters[EventType.BridgeableContractDeployed]?.bloomValueHashed ||
+        log.topics[0] === this.bloomFilters[EventType.TransferERC721]?.bloomValueHashed,
+    )
+
+    if (foundLog?.topics[0] === this.bloomFilters[EventType.BridgeableContractDeployed]?.bloomValueHashed) {
+      return CrossChainMessageType.CONTRACT
     }
 
-    let crossChainMessageType: CrossChainMessageType = CrossChainMessageType.UNKNOWN
-    for (const log of allLogs) {
-      if (log.topics[0] === crossChainMessageTopics[CrossChainMessageType.CONTRACT]) {
-        crossChainMessageType = CrossChainMessageType.CONTRACT
-        break
-      } else if (log.topics[0] === crossChainMessageTopics[CrossChainMessageType.ERC721]) {
-        crossChainMessageType = CrossChainMessageType.ERC721
-        break
-      }
+    if (foundLog?.topics[0] === this.bloomFilters[EventType.TransferERC721]?.bloomValueHashed) {
+      return CrossChainMessageType.ERC721
     }
 
-    return crossChainMessageType
+    return CrossChainMessageType.UNKNOWN
   }
 
   async checkSqsServiceAvailability(): Promise<void> {

--- a/src/handlers/sqs-indexer/handle-available-operator-job-event.ts
+++ b/src/handlers/sqs-indexer/handle-available-operator-job-event.ts
@@ -5,11 +5,13 @@ import {NetworkMonitor} from '../../utils/network-monitor'
 import SqsService from '../../services/sqs-service'
 import {networkToChainId} from '../../utils/web3'
 import {EventName, PayloadType, SqsMessageBody} from '../../types/sqs'
+import {CrossChainMessageType} from '../../utils/event/event'
 
 async function handleAvailableOperatorJobEvent(
   networkMonitor: NetworkMonitor,
   transaction: TransactionResponse,
   network: string,
+  crossChainMessageType: CrossChainMessageType,
   tags: (string | number)[],
 ): Promise<void> {
   networkMonitor.structuredLog(network, `handleAvailableOperatorJobEvent`, tags)
@@ -24,6 +26,7 @@ async function handleAvailableOperatorJobEvent(
     payload: {
       tx: transaction.hash,
       blockNum: Number(transaction.blockNumber),
+      crossChainMessageType,
     },
   }
 

--- a/src/handlers/sqs-indexer/handle-bridge-event.ts
+++ b/src/handlers/sqs-indexer/handle-bridge-event.ts
@@ -4,11 +4,13 @@ import SqsService from '../../services/sqs-service'
 import {networkToChainId} from '../../utils/web3'
 import {NetworkMonitor} from '../../utils/network-monitor'
 import {EventName, PayloadType, SqsMessageBody} from '../../types/sqs'
+import {CrossChainMessageType} from '../../utils/event/event'
 
 async function handleBridgeEvents(
   networkMonitor: NetworkMonitor,
   transaction: TransactionResponse,
   network: string,
+  crossChainMessageType: CrossChainMessageType,
   tags: (string | number)[],
 ): Promise<void> {
   const messageBody: SqsMessageBody = {
@@ -21,6 +23,7 @@ async function handleBridgeEvents(
     payload: {
       tx: transaction.hash,
       blockNum: Number(transaction.blockNumber),
+      crossChainMessageType,
     },
   }
 

--- a/src/types/sqs.ts
+++ b/src/types/sqs.ts
@@ -1,4 +1,5 @@
 import {Environment} from '@holographxyz/environment'
+import {CrossChainMessageType} from '../utils/event/event'
 
 export enum PayloadType {
   HolographProtocol = 'HolographProtocol',
@@ -22,7 +23,7 @@ export type SqsMessageBody = {
   chainId: number
   holographAddress: string
   environment: Environment
-  payload: MintEventPayload | BridgeEventPayload | TransferEventPayload
+  payload: ContractDeployedEventPayload | MintEventPayload | BridgeEventPayload | TransferEventPayload
 }
 
 export type MintEventPayload = {
@@ -43,7 +44,13 @@ export type TransferEventPayload = {
   tokenId: string
 }
 
+export type ContractDeployedEventPayload = {
+  tx: string
+  blockNum: number
+}
+
 export type BridgeEventPayload = {
   tx: string
   blockNum: number
+  crossChainMessageType: CrossChainMessageType
 }

--- a/src/utils/event/event.ts
+++ b/src/utils/event/event.ts
@@ -18,7 +18,6 @@ export enum EventType {
   TransferBatchERC1155 = 'TransferBatchERC1155',
   HolographableTransferBatchERC1155 = 'HolographableTransferBatchERC1155',
   BridgeableContractDeployed = 'BridgeableContractDeployed',
-  // BridgedContractDeployed = 'BridgedContractDeployed',
   CrossChainMessageSent = 'CrossChainMessageSent',
   AvailableOperatorJob = 'AvailableOperatorJob',
   FinishedOperatorJob = 'FinishedOperatorJob',
@@ -401,10 +400,6 @@ export const eventMap: EventMap = {
     EventType.BridgeableContractDeployed,
     'BridgeableContractDeployed(address indexed _contractAddress, bytes32 indexed _hash)',
   ),
-  // [EventType.BridgedContractDeployed]: eventBuilder(
-  //   EventType.BridgedContractDeployed,
-  //   'BridgedContractDeployed(address indexed _contractAddress, bytes32 indexed _hash)', // TODO: This isn't a real event type
-  // ),
   [EventType.CrossChainMessageSent]: eventBuilder(
     EventType.CrossChainMessageSent,
     'CrossChainMessageSent(bytes32 _messageHash)',

--- a/src/utils/event/event.ts
+++ b/src/utils/event/event.ts
@@ -18,6 +18,7 @@ export enum EventType {
   TransferBatchERC1155 = 'TransferBatchERC1155',
   HolographableTransferBatchERC1155 = 'HolographableTransferBatchERC1155',
   BridgeableContractDeployed = 'BridgeableContractDeployed',
+  // BridgedContractDeployed = 'BridgedContractDeployed',
   CrossChainMessageSent = 'CrossChainMessageSent',
   AvailableOperatorJob = 'AvailableOperatorJob',
   FinishedOperatorJob = 'FinishedOperatorJob',
@@ -26,6 +27,14 @@ export enum EventType {
   V1PacketLZ = 'V1PacketLZ',
   TestLzEvent = 'TestLzEvent',
   HolographableContractEvent = 'HolographableContractEvent',
+}
+
+export enum CrossChainMessageType {
+  UNKNOWN = 'UNKNOWN',
+  ERC721 = 'ERC721',
+  ERC1155 = 'ERC1155',
+  ERC20 = 'ERC20',
+  CONTRACT = 'CONTRACT',
 }
 
 export interface BaseEvent {
@@ -392,6 +401,10 @@ export const eventMap: EventMap = {
     EventType.BridgeableContractDeployed,
     'BridgeableContractDeployed(address indexed _contractAddress, bytes32 indexed _hash)',
   ),
+  // [EventType.BridgedContractDeployed]: eventBuilder(
+  //   EventType.BridgedContractDeployed,
+  //   'BridgedContractDeployed(address indexed _contractAddress, bytes32 indexed _hash)', // TODO: This isn't a real event type
+  // ),
   [EventType.CrossChainMessageSent]: eventBuilder(
     EventType.CrossChainMessageSent,
     'CrossChainMessageSent(bytes32 _messageHash)',

--- a/src/utils/event/filter.ts
+++ b/src/utils/event/filter.ts
@@ -1,7 +1,6 @@
 /* eslint-disable unicorn/no-abusive-eslint-disable */
 /* eslint-disable */
 import {Log, TransactionResponse} from '@ethersproject/abstract-provider'
-import {keccak256} from '@ethersproject/keccak256'
 
 import {Event, EventType, eventMap} from './event'
 


### PR DESCRIPTION
## Describe Changes

- Enables differentiating between NFT and CONTRACT cross chain messages
- Adds a new function `detectCrossChainMessageType` that is called within the `EventType.CrossChainMessageSent` block and the `EventType.AvailableOperatorJob` blocks of the `processSingTransaction` function to send the correct type (at the moment either CONTRACT or ERC721) through sqs to the processor
- Updates `BridgeEventPayload` to allow passing a `crossChainMessageType`
- Adds a separate sqs event type for `ContractDeployedEventPayload`
- Includes that as one of the options of payload format in `SqsMessageBody`

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
