### PR TITLE
Feature/holo 1083 group multiple crosschain logs

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# yarn lint
-# yarn prettier:check
+yarn lint
+yarn prettier:check

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn lint
-yarn prettier:check
+# yarn lint
+# yarn prettier:check

--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -295,6 +295,35 @@ export default class Indexer extends HealthCheck {
       return
     }
 
+    // Preprocess the transactions to group them by transaction hash
+    console.log(interestingTransactions)
+    const groupedByTransactionHash: any = {}
+
+    interestingTransactions.forEach(item => {
+      const hash = item.transaction.hash
+
+      // Initialize if not already
+      if (!groupedByTransactionHash[hash]) {
+        groupedByTransactionHash[hash] = {
+          bloomId: item.bloomId,
+          transaction: item.transaction,
+          log: item.log, // Add this line
+          allLogs: [],
+        }
+      }
+
+      // Concatenate all logs into the array
+      if (item.allLogs) {
+        groupedByTransactionHash[hash].allLogs.push(...item.allLogs)
+      }
+    })
+
+    console.log('^^^^^^^^^^^')
+    // console.log(JSON.stringify(groupedByTransactionHash))
+    interestingTransactions = Object.values(groupedByTransactionHash)
+
+    console.log(interestingTransactions)
+
     // Map over the transactions to create an array of Promises
     const transactionPromises = interestingTransactions.map(interestingTransaction =>
       this.processSingleTransaction(interestingTransaction, job),


### PR DESCRIPTION
## Describe Changes

- Adds a new function to the indexer `preprocessTransactions`
- This is to prevent the case where the processor is getting duplicate sqs events for batch deployments and sending of exponential amounts of requests to the API

Here's the summary of how it works:

```
* Preprocesses a list of transactions to remove duplicates based on a combination of transaction hash and the bloomId.
* Specifically, it filters out duplicate entries where the bloomId is 'CrossChainMessageSent'.
*
* How it works:
* 1. Iterates over each transaction.
* 2. Creates a unique identifier using the transaction hash and bloomId.
* 3. If the bloomId is 'CrossChainMessageSent' and the identifier is already seen, the transaction is skipped.
* 4. Otherwise, the transaction is processed: it's added to the groupedByTransactionHashAndBloomId dictionary and the updatedInterestingTransactions array.
* 5. The end result is a list of transactions with duplicates (based on the specific criteria) removed.
   ```

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
