### PR TITLE
Improvement / HOLO 1182 Decode Packet handles multiple messaging module addresses

### DIFF
--- a/src/events/events.ts
+++ b/src/events/events.ts
@@ -64,47 +64,38 @@ const failedOperatorJobEventFragment: EventFragment = EventFragment.from('Failed
 
 export function decodeLzPacketEvent(
   receipt: TransactionReceipt,
-  messagingModuleAddress: string,
+  providedMessagingModuleAddress: string,
   target?: string,
 ): string | undefined {
   if (target !== undefined) {
     target = target.toLowerCase().trim()
   }
 
-  const toFind = messagingModuleAddress.slice(2, 42)
-  if ('logs' in receipt && receipt.logs !== null && receipt.logs.length > 0) {
-    for (let i = 0, l = receipt.logs.length; i < l; i++) {
-      const log = receipt.logs[i]
-      if (
-        log.topics[0] === targetEvents.LzPacket &&
-        (target === undefined || (target !== undefined && log.address.toLowerCase() === target))
-      ) {
-        const packetPayload = iface.decodeEventLog(lzPacketEventFragment, log.data, log.topics)[0] as string
-        if (packetPayload.indexOf(toFind) > 0) {
-          let index: number = packetPayload.indexOf(toFind)
-          // address + bytes2 + address
-          index += 40 + 4 + 40
-          return ('0x' + packetPayload.slice(Math.max(0, index))).toLowerCase()
-        }
-      }
-    }
-  }
-
   // This is a fallback for the legacy messaging module address that was updated for all networks except for optimism
-  const toFind2 = '0x803305930C1bbae396D03F496a7bF53Ad7fd4303'.toLowerCase().slice(2, 42)
-  if ('logs' in receipt && receipt.logs !== null && receipt.logs.length > 0) {
-    for (let i = 0, l = receipt.logs.length; i < l; i++) {
-      const log = receipt.logs[i]
-      if (
-        log.topics[0] === targetEvents.LzPacket &&
-        (target === undefined || (target !== undefined && log.address.toLowerCase() === target))
-      ) {
-        const packetPayload = iface.decodeEventLog(lzPacketEventFragment, log.data, log.topics)[0] as string
-        if (packetPayload.indexOf(toFind2) > 0) {
-          let index: number = packetPayload.indexOf(toFind2)
-          // address + bytes2 + address
-          index += 40 + 4 + 40
-          return ('0x' + packetPayload.slice(Math.max(0, index))).toLowerCase()
+  const messagingModuleAddresses = [
+    providedMessagingModuleAddress,
+    '0xc9264255e1ae0cc80ceadd0056c63dc1caed28ad',
+    '0xe9e30a0ad0d8af5cf2606ea720052e28d6fcbaaf',
+    '0x6f484eacd997d9880205af22f6a4881ea0e1ccd7',
+    '0x803305930c1bbae396d03f496a7bf53ad7fd4303',
+  ]
+
+  for (const messagingModuleAddress of messagingModuleAddresses) {
+    const toFind = messagingModuleAddress.slice(2, 42)
+    if ('logs' in receipt && receipt.logs !== null && receipt.logs.length > 0) {
+      for (let i = 0, l = receipt.logs.length; i < l; i++) {
+        const log = receipt.logs[i]
+        if (
+          log.topics[0] === targetEvents.LzPacket &&
+          (target === undefined || (target !== undefined && log.address.toLowerCase() === target))
+        ) {
+          const packetPayload = iface.decodeEventLog(lzPacketEventFragment, log.data, log.topics)[0] as string
+          if (packetPayload.indexOf(toFind) > 0) {
+            let index: number = packetPayload.indexOf(toFind)
+            // address + bytes2 + address
+            index += 40 + 4 + 40
+            return ('0x' + packetPayload.slice(Math.max(0, index))).toLowerCase()
+          }
         }
       }
     }


### PR DESCRIPTION
## Describe Changes

- Add new message module addresses to `decodeLzPacketEvent`

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
