### PR TITLE
Hotfix/disable api when not updating block height flag is disabled

### DIFF
--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -108,7 +108,11 @@ export default class Indexer extends HealthCheck {
       updateBlockHeight = BlockHeightOptions.DISABLE
     }
 
-    if (this.environment === Environment.localhost || this.environment === Environment.experimental || updateBlockHeight === 'disable') {
+    if (
+      this.environment === Environment.localhost ||
+      this.environment === Environment.experimental ||
+      updateBlockHeight === 'disable'
+    ) {
       this.log(`Skipping API authentication for ${Environment[this.environment]} environment`)
     } else {
       // Create API Service for GraphQL requests

--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -108,7 +108,7 @@ export default class Indexer extends HealthCheck {
       updateBlockHeight = BlockHeightOptions.DISABLE
     }
 
-    if (this.environment === Environment.localhost || this.environment === Environment.experimental) {
+    if (this.environment === Environment.localhost || this.environment === Environment.experimental || updateBlockHeight === 'disable') {
       this.log(`Skipping API authentication for ${Environment[this.environment]} environment`)
     } else {
       // Create API Service for GraphQL requests


### PR DESCRIPTION
## Describe Changes

I made this better by doing ...

- when the `update-block-height` flag is set, do not try and call the API

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
