### PR TITLE
Hotfix / Block processing V2 fix

### DIFF
--- a/src/commands/indexer/index.ts
+++ b/src/commands/indexer/index.ts
@@ -272,6 +272,7 @@ export default class Indexer extends HealthCheck {
             [EventType.SecondarySaleFees]: buildEventFilter(EventType.SecondarySaleFees),
             [EventType.MintFeePayout]: buildEventFilter(EventType.MintFeePayout),
             [EventType.Sale]: buildEventFilter(EventType.Sale),
+            [EventType.TransferERC721]: buildEventFilter(EventType.TransferERC721, undefined, ContractType.ERC721),
           }
 
     this.bloomFilters = {


### PR DESCRIPTION
## Describe Changes

I made this better by doing ...

When the `process-block-range` flag is set to `true`, the indexer's `bloomFilters` lack the `TransferErc721` event, which is essential for identifying mints using BlockProcessingVersion V2.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
