### PR TITLE
Hotfix / Process blocks by range with process blocks V2 fix

### DIFF
--- a/src/utils/protocol-events-map.ts
+++ b/src/utils/protocol-events-map.ts
@@ -155,7 +155,6 @@ function validateTransaction(
 ): boolean {
   if (protocolEvent.contractMethodName) {
     if (
-      interestingTransaction.transaction &&
       interestingTransaction.transaction.data &&
       interestingTransaction.transaction.data.startsWith(protocolEvent.contractMethodName) === false
     ) {
@@ -171,7 +170,7 @@ function validateTransaction(
         return false
       }
     }
-  } else if (interestingTransaction.transaction && interestingTransaction.transaction.data) {
+  } else if (interestingTransaction.transaction.data) {
     const txMethodId = interestingTransaction.transaction.data.slice(0, 10) // 0x + first 4 bytes (8 digits)
     const methodIds = new Set(Object.values(ContractMethodId) as string[])
     if (methodIds.has(txMethodId)) {


### PR DESCRIPTION


## Describe Changes


**⚠️ Problem:**

- The `processBlockByRange` function mistakenly assigns the `TransactionResponse` type to the transactions array.

- This error directly disrupts the functionality of block processing V2.

**✅ Solution:**

- Introduced a hotfix to ensure the correct type assignment for the block process version V2 flow.

- Prioritized efficiency and effectiveness in this immediate fix.

** Next Steps:**

- A more robust and sustainable solution to address the root cause of this issue should be added later.


## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Code styles have been enforced
- [x] I have checked eslint
